### PR TITLE
Memh5 dataset creation in other groups.

### DIFF
--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -367,9 +367,19 @@ class MemGroup(ro_dict):
         dset : memh5.MemDataset
         """
 
-        # For the moment raise an Exception if we try to use absolute paths
-        if name[0] == '/':
-            raise ValueError('Dataset creation does not support absolute paths (%s)' % name)
+        if '/' in name:
+            parts = name.split('/')
+            name = parts[-1]
+            # Corner case of name = '/dataset_name'.
+            if len(parts) == 2 and not parts[0]:
+                group_name = '/'
+            else:
+                group_name = '/'.join(parts[:-1])
+            g = self.require_group(group_name)
+            self = g    # XXX Is this really okay?
+
+        if not name:
+            raise ValueError('Empty dataset names not allowed.')
 
         # If distributed, synchronise to ensure that we create group collectively
         if self._distributed:

--- a/caput/tests/test_memh5.py
+++ b/caput/tests/test_memh5.py
@@ -52,6 +52,16 @@ class TestGroup(unittest.TestCase):
         gd = g['/a/b/c/d/']
         self.assertEqual(gd.name, '/a/b/c/d')
 
+    def test_recursive_create_dataset(self):
+        g = memh5.MemGroup()
+        data = np.arange(10)
+        g.create_dataset('a/ra', data=data)
+        self.assertTrue(memh5.is_group(g['a']))
+        self.assertTrue(np.all(g['a/ra'] == data))
+        g['a'].create_dataset('/ra', data=data)
+        print g.keys()
+        self.assertTrue(np.all(g['ra'] == data))
+
 
 class TestH5Files(unittest.TestCase):
     """Tests that make hdf5 objects, convert to mem and back."""


### PR DESCRIPTION
This addresses #16. MemGroup.create_dataset can now take either a
relative or absolute path as the name such that the dataset can be
created in an different group from the calling group.