### PR TITLE
Improvements to how skyfield data is treated

### DIFF
--- a/caput/time.py
+++ b/caput/time.py
@@ -134,6 +134,7 @@ and a complete cycle of ERA.
 """
 
 from datetime import datetime
+import warnings
 
 import numpy as np
 
@@ -695,7 +696,6 @@ def naive_datetime_to_utc(dt):
         global _warned_utc_datetime
 
         if not _warned_utc_datetime:
-            import warnings
 
             warnings.warn('Skyfield not installed. Cannot add UTC timezone to datetime.')
             _warned_utc_datetime = True
@@ -748,7 +748,7 @@ class SkyfieldWrapper(object):
     reload
     """
 
-    def __init__(self, path=None, expire=False, ephemeris='de421.bsp'):
+    def __init__(self, path=None, expire=True, ephemeris='de421.bsp'):
 
         import os
 
@@ -795,7 +795,13 @@ class SkyfieldWrapper(object):
         and then cached."""
 
         if self._timescale is None:
-            self._timescale = self.load.timescale()
+            try:
+                self._timescale = self.load.timescale()
+            except:
+                warnings.warn("Could not update Skyfield data to more recent version. Trying existing data.")
+                self.load.expire = False
+                self._timescale = self.load.timescale()
+
         return self._timescale
 
     _ephemeris = None
@@ -806,7 +812,13 @@ class SkyfieldWrapper(object):
         Loaded at first call, and then cached."""
 
         if self._ephemeris is None:
-            self._ephemeris = self.load(self._ephemeris_name)
+            try:
+                self._ephemeris = self.load(self._ephemeris_name)
+            except:
+                warnings.warn("Could not update Skyfield data to more recent version. Trying existing data.")
+                self.load.expire = False
+                self._ephemeris = self.load(self._ephemeris_name)
+
         return self._ephemeris
 
     def reload(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 h5py
 PyYAML
+skyfield>=1.0

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,29 @@ if on_rtd:
 else:
     requires = REQUIRES
 
+
+# Try and install Skyfield data
+try:
+    from caput import time as ctime
+
+    # Force download of data
+    ctime.skyfield_wrapper.reload()
+
+    # Set package data to be installed alongside skyfield
+    skyfield_data = {
+        'caput': [
+            'data/Leap_Second.dat',
+            'data/de421.bsp',
+            'data/deltat.data',
+            'data/deltat.preds'
+        ]
+    }
+
+except:
+    import warnings
+    warnings.warn("Could not install additional Skyfield data.")
+    skyfield_data = None
+
 setup(
     name='caput',
     version=__version__,
@@ -20,9 +43,10 @@ setup(
     scripts=['scripts/caput-pipeline'],
     install_requires=requires,
     extras_require={
-        'mpi': ['mpi4py>=1.3'],
-        'skyfield': ['skyfield>=1.0']
+        'mpi': ['mpi4py>=1.3']
     },
+
+    package_data=skyfield_data,
 
     # metadata for upload to PyPI
     author="Kiyo Masui, J. Richard Shaw",


### PR DESCRIPTION
Caput will now initially try and install the skyfield when the package installs. It will also now use attempt to update the data when it is first used and otherwise use existing data.