### PR TITLE
config key exceptions

### DIFF
--- a/caput/config.py
+++ b/caput/config.py
@@ -138,7 +138,7 @@ class Property(object):
         if self.key in config:
             val = self.proptype(config[self.key])
             obj.__dict__[self.propname] = val
-      
+
     def _set_propname(self, obj):
         # As this config.Property instance lives on the class it's in, it
         # doesn't actually know what it's name is. We need to search the class
@@ -198,13 +198,13 @@ class Reader(object):
                     prop_keys.append(clsprop.key)             
 
         if compare_keys:
-            if set(config_keys)-set(prop_keys):
+            if set(config_keys) - set(prop_keys):
                 raise Exception("Configuration keys [%s] do not have corresponding properties" 
-                                % ", ".join(set(config_keys)-set(prop_keys)))
+                                % ", ".join(set(config_keys) - set(prop_keys)))
         if not use_defaults:
-            if set(prop_keys)-set(config_keys):
+            if set(prop_keys) - set(config_keys):
                 raise Exception("Property keys [%s] are not present in configuration dictionary" 
-                                % ", ".join(set(prop_keys)-set(config_keys)))
+                                % ", ".join(set(prop_keys) - set(config_keys)))
         
         self._finalise_config()
 

--- a/caput/config.py
+++ b/caput/config.py
@@ -138,7 +138,7 @@ class Property(object):
         if self.key in config:
             val = self.proptype(config[self.key])
             obj.__dict__[self.propname] = val
-
+      
     def _set_propname(self, obj):
         # As this config.Property instance lives on the class it's in, it
         # doesn't actually know what it's name is. We need to search the class
@@ -173,21 +173,39 @@ class Reader(object):
 
         return c
 
-    def read_config(self, config):
+    def read_config(self, config, compare_keys=False, use_defaults=True):
         """Set all properties in this class from the supplied config.
 
         Parameters
         ----------
         config : dict
             Dictionary of configuration values.
+        compare_keys : bool
+            If True, an exception is raised if there are unused keys in the
+            config dictionary
+        use_defaults : bool
+            If False, an exception is raised if a property is not defined by
+            the config dictionary
         """
         import inspect
-
+        
+        config_keys = [x for x in config.keys()]
+        prop_keys = []
         for basecls in inspect.getmro(type(self))[::-1]:
             for propname, clsprop in basecls.__dict__.items():
                 if isinstance(clsprop, Property):
                     clsprop._from_config(self, config)
+                    prop_keys.append(clsprop.key)             
 
+        if compare_keys:
+            if set(config_keys)-set(prop_keys):
+                raise Exception("Configuration keys [%s] do not have corresponding properties" 
+                                % ", ".join(set(config_keys)-set(prop_keys)))
+        if not use_defaults:
+            if set(prop_keys)-set(config_keys):
+                raise Exception("Property keys [%s] are not present in configuration dictionary" 
+                                % ", ".join(set(prop_keys)-set(config_keys)))
+        
         self._finalise_config()
 
     def _finalise_config(self):


### PR DESCRIPTION
Modify config.Reader to raise exceptions if there are discrepancies between keys in the configuration dictionary and Properties