### PR TITLE
Required property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# vim backups and swap files
+.*.swp
+*~

--- a/caput/config.py
+++ b/caput/config.py
@@ -119,7 +119,7 @@ class Property(object):
                         self.__class__.__name__))
         elif self.default is not None:
             # Otherwise, return the default, if provided
-            return self.prototype(self.default)
+            return self.proptype(self.default)
 
         # In all other cases, return None as a last resort
         return None


### PR DESCRIPTION
This is a complement to Dallas's enhancement which allows declaring `Property`s which are required to be initialised from the dictionary and have no sensible default value.

It adds an fourth, optional parameter, `required`, to the `Property` constructor which defaults to `False`. If set to `True`, then `AttributeError` will be raised if an attempt is made to access the instanced attribute before it is set.

Also, because setting a default doesn't make sense for these "required" properties (since it can never be returned), `ValueError` will be raised if the `Property` constructor is called with `default` not `None` and `required=True`.