### PR TITLE
Fix cyclic references

### DIFF
--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -75,6 +75,7 @@ import collections
 import warnings
 import posixpath
 from ast import literal_eval
+import weakref
 
 import numpy as np
 import h5py
@@ -630,7 +631,7 @@ class MemGroup(_BaseGroup):
 
         # Set the properties of the new dataset
         new_dataset._name = posixpath.join(parent_name, name)
-        new_dataset._storage_root = self._storage_root
+        new_dataset._storage_root = weakref.ref(self._storage_root)
         return new_dataset
 
     def dataset_common_to_distributed(self, name, distributed_axis=0):

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -652,7 +652,8 @@ class MemGroup(_BaseGroup):
         dset = self[name]
 
         if dset.distributed:
-            warnings.warn('%s is already a distributed dataset, redistribute it along the required axis %d' % (name, distributed_axis))
+            warnings.warn('%s is already a distributed dataset, redistribute it along the required axis %d'
+                          % (name, distributed_axis))
             dset.redistribute(distributed_axis)
             return dset
 
@@ -665,7 +666,14 @@ class MemGroup(_BaseGroup):
         attr_dict = {} # temporarily save attrs of this dataset
         copyattrs(dset.attrs, attr_dict)
         del dset
-        new_dset = self.create_dataset(name, shape=dset_shape, dtype=dset_type, data=md, distributed=True, distributed_axis=distributed_axis)
+        new_dset = self.create_dataset(
+                name,
+                shape=dset_shape,
+                dtype=dset_type,
+                data=md,
+                distributed=True,
+                distributed_axis=distributed_axis,
+                )
         copyattrs(attr_dict, new_dset.attrs)
 
         return new_dset
@@ -726,6 +734,10 @@ class MemDataset(_MemObjMixin):
     def __init__(self, **kwargs):
         super(MemDataset, self).__init__(**kwargs)
         self._attrs = MemAttrs()
+
+    @property
+    def _group_class(self):
+        return MemGroup
 
     @property
     def attrs(self):

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -1148,7 +1148,7 @@ class MemDiskGroup(_BaseGroup):
         """Finish the class setup *after* importing from a file."""
         pass
 
-    def __del__(self):
+    def close(self):
         """Closes file if on disk if file was opened on initialization."""
         if self.ondisk and hasattr(self, '_toclose') and self._toclose:
             self._storage_root.close()

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -1133,6 +1133,12 @@ class MemDiskGroup(_BaseGroup):
         self._toclose = toclose
         super(MemDiskGroup, self).__init__(storage_root=data_group, name=data_group.name)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     @classmethod
     def from_group(cls, data_group=None, detect_subclass=True):
         """Create data object from a given group.

--- a/caput/tests/test_memh5.py
+++ b/caput/tests/test_memh5.py
@@ -66,8 +66,8 @@ class TestGroup(unittest.TestCase):
         self.assertTrue(memh5.is_group(g['a']))
         self.assertTrue(np.all(g['a/ra'][:] == data))
         g['a'].create_dataset('/ra', data=data)
-        print(list(g.keys()))
         self.assertTrue(np.all(g['ra'][:] == data))
+        self.assertIsInstance(g['a/ra'].parent, memh5.MemGroup)
 
 
 class TestH5Files(unittest.TestCase):
@@ -159,13 +159,21 @@ class TestMemDiskGroup(unittest.TestCase):
         # Save a subclass of MemDiskGroup
         tsc = TempSubClass()
         tsc.create_dataset('dset', data=np.arange(10))
-        tsc.save('temp_mdg.h5')
+        tsc.save(self.fname)
 
         # Load it from disk
-        tsc2 = memh5.MemDiskGroup.from_file('temp_mdg.h5')
+        tsc2 = memh5.MemDiskGroup.from_file(self.fname)
+        tsc3 = memh5.MemDiskGroup.from_file(self.fname, ondisk=True)
 
         # Check that is is recreated with the correct type
         self.assertIsInstance(tsc2, TempSubClass)
+        self.assertIsInstance(tsc3, TempSubClass)
+
+        # Check that parent/etc is properly implemented.
+        # Turns out this is very hard so give up for now.
+        #self.assertIsInstance(tsc2['dset'].parent, TempSubClass)
+        #self.assertIsInstance(tsc3['dset'].parent, TempSubClass)
+        tsc3.close()
 
     def tearDown(self):
         file_names = glob.glob(self.fname + '*')

--- a/caput/tests/test_memh5.py
+++ b/caput/tests/test_memh5.py
@@ -10,6 +10,7 @@ from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
 import unittest
 import os
 import glob
+import gc
 
 import numpy as np
 import h5py
@@ -48,6 +49,7 @@ class TestGroup(unittest.TestCase):
         g.create_dataset('data', data=data)
         self.assertTrue(np.allclose(data, g['data']))
 
+
     def test_recursive_create(self):
         g = memh5.MemGroup()
         self.assertRaises(ValueError, g.create_group, '')
@@ -68,6 +70,12 @@ class TestGroup(unittest.TestCase):
         g['a'].create_dataset('/ra', data=data)
         self.assertTrue(np.all(g['ra'][:] == data))
         self.assertIsInstance(g['a/ra'].parent, memh5.MemGroup)
+
+        # Check that d keeps g in scope.
+        d = g['a/ra']
+        del g
+        gc.collect()
+        self.assertTrue(np.all(d.file['ra'][:] == data))
 
 
 class TestH5Files(unittest.TestCase):

--- a/caput/tests/test_memh5.py
+++ b/caput/tests/test_memh5.py
@@ -183,6 +183,13 @@ class TestMemDiskGroup(unittest.TestCase):
         #self.assertIsInstance(tsc3['dset'].parent, TempSubClass)
         tsc3.close()
 
+        with memh5.MemDiskGroup.from_file(self.fname, ondisk=True) as tsc4:
+            self.assertRaises(IOError, h5py.File, self.fname, 'w')
+
+        with memh5.MemDiskGroup.from_file(self.fname, ondisk=False) as tsc4:
+            f = h5py.File(self.fname, 'w')
+            f.close()
+
     def tearDown(self):
         file_names = glob.glob(self.fname + '*')
         for fname in file_names:


### PR DESCRIPTION
Here are two changes that fix cyclic references and garbage collection.

Changing `MemDataset._storage_root` to a weak reference fixes what I think is the last remaining cyclic reference. I found this using the excellent `objgraph` package. It is as simple as `import objgraph; objgraph.show_refs(data, filename='sample-graph.png')`.

The second is less backward compatible: it removes automatic file closure. This is more inline with how h5py closes files. More importantly, @rmck1 found the following in the python docs: "Objects that have del() methods and are part of a reference cycle cause the entire reference cycle to be uncollectable.", so the existence of __del__ makes the whole container less robust to memory leaks. Seems like a good idea to get rid of it.

Thanks @rmck1 for figuring most of this out!