### PR TITLE
Concat dist bugfix

### DIFF
--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -1296,11 +1296,12 @@ def _format_product_keys(spec, name):
         # Default to empty if not present.
         return []
     # Turn into a sequence if only one key was provided.
-    if not type(out_prod) is list:
+    if not isinstance(out_prod, list):
         # Making this a tuple instead of a list is significant.  It only
         # impacts the 'out' product key and affects how return values are
         # unpacked.
         out_prod = (out_prod,)
+
     # Check that all the keys provided are strings.
     for prod in out_prod:
         if not isinstance(prod, basestring):


### PR DESCRIPTION
This fixes two bugs.  The first is just a `type() is list` comparison that no longer works in newer versions of python.

The second occurs when concatenating distributed datasets that I think may have been introduced in [4343059](https://github.com/radiocosmology/caput/commit/434305988e4e4260be19320080f596efe22e8204#diff-b295d0d06e0d6df9609f55b50997befc).

Applying the time slice to `dataset` converts it from an instance of `MemDataset` to either an `MPIArray` or `np.ndarray`.

For distributed datasets, this causes the `isinstance(dataset, memh5.MemDatasetDistributed)` condition to fail, and the output dataset is initialized as non-distributed.

The proposed fix converts back to either `MemDatasetCommon` or `MemDatasetDistributed` after applying the time slice.  It determines which one to use by checking if `dataset` is an instance of `MPIArray`.  People that are more familiar with the code may have a better way to do this.