### PR TITLE
rewrite MPIArray redistribute without transpose_blocks

### DIFF
--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -497,9 +497,8 @@ class MPIArray(np.ndarray):
                 request.Wait(status=stat)
 
                 if stat.error != mpiutil.MPI.SUCCESS:
-                    print
-                    "**** ERROR in MPI SEND (r: %i c: %i rank: %i) *****" % (
-                    ir, ic, self.comm.rank)
+                    print("**** ERROR in MPI SEND (r: %i c: %i rank: %i) *****"
+                          .format(ir, ic, self.comm.rank))
 
             self.comm.Barrier()
 
@@ -512,9 +511,8 @@ class MPIArray(np.ndarray):
                 request.Wait(status=stat)
 
                 if stat.error != mpiutil.MPI.SUCCESS:
-                    print
-                    "**** ERROR in MPI RECV (r: %i c: %i rank: %i) *****" % (
-                    ir, ir, self.comm.rank)
+                    print("**** ERROR in MPI RECV (r: %i c: %i rank: %i) *****"
+                          .format(ir, ir, self.comm.rank))
 
             # Put together the blocks we received
             np.concatenate(buffers, self.axis, trans_arr)

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -20,7 +20,7 @@ from caput import mpiutil, mpiarray
 
 
 
-class TestMPIAray(unittest.TestCase):
+class TestMPIArray(unittest.TestCase):
 
     def test_construction(self):
 


### PR DESCRIPTION
Instead of receiving blocks in-place, this creates a numpy array for each block, that is then copied into the new local array. This is because slicing by indexes for the local array on a variable axis does not result in a contiguous array accepted by `mpi4py.MPI.Recv`. Suggestions are welcome!
#43 