### PR TITLE
Parallel container IO using h5py and MPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ with memh5.BasicCont.from_file("filename.h5"):
 - Support for new CHIME stacked data with `reverse_map` (#58)
 - Better handling of missing config information (#56)
 
+### Changed
+
+- IO for distributed `memh5` containers is now MPI parallel if possible (#66).
+  This should make a big difference to write times of large containers.
+
 ### Fixed
 
 - Fixed circular references in memh5 containers (#60)

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -22,6 +22,11 @@ objects and can be written to, and loaded from disk like normal :class:`memh5`
 objects.  Support for this must be explicitly enabled in the root group at
 creation with the `distributed=True` flag.
 
+.. warning::
+    It has been observed that the parallel write of distributed datasets can
+    lock up. This was when using macOS using `ompio` of OpenMPI 3.0.
+    Switching to `romio` as the MPI-IO backend helped here, but please report
+    any further issues.
 
 Basic Classes
 =============

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -81,11 +81,10 @@ import h5py
 
 from . import mpiutil
 from . import mpiarray
-
+from . import misc
 
 # Basic Classes
 # -------------
-
 
 
 class ro_dict(collections.Mapping):
@@ -474,7 +473,10 @@ class MemGroup(_BaseGroup):
             with h5py.File(filename, **kwargs) as f:
                 deep_group_copy(self, f)
         else:
-            _distributed_group_to_hdf5(self, filename, **kwargs)
+            if h5py.get_config().mpi:
+                _distributed_group_to_hdf5_parallel(self, filename, **kwargs)
+            else:
+                _distributed_group_to_hdf5_serial(self, filename, **kwargs)
 
     def create_group(self, name):
         """Create a group within the storage tree."""
@@ -1762,9 +1764,12 @@ def format_abs_path(path):
     return out
 
 
-def _distributed_group_to_hdf5(group, fname, hints=True, **kwargs):
-    """Private routine to copy full data tree from distributed memh5 object into an
-    HDF5 file."""
+def _distributed_group_to_hdf5_serial(group, fname, hints=True, **kwargs):
+    """Private routine to copy full data tree from distributed memh5 object
+    into an HDF5 file.
+
+    This version explicitly serialises all IO.
+    """
 
     if not group.distributed:
         raise RuntimeError('This should only run on distributed datasets [%s].' % group.name)
@@ -1840,6 +1845,67 @@ def _distributed_group_to_hdf5(group, fname, hints=True, **kwargs):
     comm.Barrier()
 
 
+def _distributed_group_to_hdf5_parallel(group, fname, hints=True, **kwargs):
+    """Private routine to restore full tree from an HDF5 file into a distributed memh5 object."""
+
+    # == Create some internal functions for doing the read ==
+    # Function to perform a recursive clone of the tree structure
+    def _copy_to_file(memgroup, h5group):
+
+        # Copy over attributes
+        copyattrs(memgroup.attrs, h5group.attrs)
+
+        for key, item in memgroup.items():
+
+            # If group, create the entry and the recurse into it
+            if is_group(item):
+                new_group = h5group.create_group(key)
+                _copy_to_file(item, new_group)
+
+            # If dataset, create dataset
+            else:
+
+                # Check if we are in a distributed dataset
+                if isinstance(item, MemDatasetDistributed):
+
+                    # Read from file into MPIArray
+                    item.data.to_hdf5(h5group, key)
+                    dset = h5group[key]
+
+                    if hints:
+                        dset.attrs['__memh5_distributed_dset'] = True
+
+                else:
+                    # Create dataset (collective)
+                    dset = h5group.create_dataset(key, shape=item.shape, dtype=item.dtype)
+
+                    # Write common data from rank 0
+                    if memgroup.comm.rank == 0:
+                        dset[:] = item
+
+                    if hints:
+                        dset.attrs['__memh5_distributed_dset'] = False
+
+                # Copy attributes over into dataset
+                copyattrs(item.attrs, dset.attrs)
+
+
+    # Open file on all ranks
+    mode = kwargs.get('mode', 'w')
+    with misc.open_h5py_mpi(fname, mode, comm=group.comm) as f:
+        if not f.is_mpi:
+            raise RuntimeError("Could not create file %s in MPI mode" % fname)
+
+        # Start recursive file read
+        _copy_to_file(group, f)
+
+        if hints:
+            f.attrs['__memh5_distributed_file'] = True
+
+    # Final synchronisation
+    group.comm.Barrier()
+
+
 def _distributed_group_from_hdf5(fname, comm=None, hints=True, **kwargs):
     """Private routine to restore full tree from an HDF5 file into a distributed memh5 object."""
 
@@ -1876,7 +1942,7 @@ def _distributed_group_from_hdf5(fname, comm=None, hints=True, **kwargs):
                 if ('__memh5_distributed_dset' in item.attrs) and item.attrs['__memh5_distributed_dset']:
 
                     # Read from file into MPIArray
-                    pdata = mpiarray.MPIArray.from_hdf5(f, key, comm=comm)
+                    pdata = mpiarray.MPIArray.from_hdf5(h5group, key, comm=comm)
 
                     # Create dataset from MPIArray
                     dset = memgroup.create_dataset(key, data=pdata, distributed=True)
@@ -1895,7 +1961,7 @@ def _distributed_group_from_hdf5(fname, comm=None, hints=True, **kwargs):
                 _copy_attrs_bcast(item, dset)
 
     # Open file on all ranks
-    with h5py.File(fname, 'r') as f:
+    with misc.open_h5py_mpi(fname, 'r', comm=comm) as f:
 
         # Start recursive file read
         _copy_from_file(f, group)
@@ -1941,4 +2007,3 @@ def bytes_to_unicode(s):
         return {bytes_to_unicode(k): bytes_to_unicode(v) for k, v in s.items()}
 
     return s
-

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -1806,7 +1806,7 @@ def _distributed_group_to_hdf5_serial(group, fname, hints=True, **kwargs):
 
         # Groups are written out by recursing
         if is_group(entry):
-            _distributed_group_to_hdf5(entry, fname, **kwargs)
+            _distributed_group_to_hdf5_serial(entry, fname, **kwargs)
 
         # Write out distributed datasets (only the data, the attributes are written below)
         elif isinstance(entry, MemDatasetDistributed):

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -1896,7 +1896,9 @@ def _distributed_group_to_hdf5_serial(group, fname, hints=True, **kwargs):
 
 
 def _distributed_group_to_hdf5_parallel(group, fname, hints=True, **kwargs):
-    """Private routine to restore full tree from an HDF5 file into a distributed memh5 object."""
+    """Private routine to copy full data tree from distributed memh5 object
+    into an HDF5 file.
+    This version paralellizes all IO."""
 
     # == Create some internal functions for doing the read ==
     # Function to perform a recursive clone of the tree structure
@@ -1918,7 +1920,7 @@ def _distributed_group_to_hdf5_parallel(group, fname, hints=True, **kwargs):
                 # Check if we are in a distributed dataset
                 if isinstance(item, MemDatasetDistributed):
 
-                    # Read from file into MPIArray
+                    # Write to file from MPIArray
                     item.data.to_hdf5(h5group, key)
                     dset = h5group[key]
 
@@ -1946,7 +1948,7 @@ def _distributed_group_to_hdf5_parallel(group, fname, hints=True, **kwargs):
         if not f.is_mpi:
             raise RuntimeError("Could not create file %s in MPI mode" % fname)
 
-        # Start recursive file read
+        # Start recursive file write
         _copy_to_file(group, f)
 
         if hints:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -538,8 +538,9 @@ class MPIArray(np.ndarray):
         import h5py
 
         if not h5py.get_config().mpi:
-            if isinstance(filename, basestring):
-                self._to_hdf5_serial(filename, dataset, create)
+            if isinstance(f, basestring):
+                self._to_hdf5_serial(f, dataset, create)
+                return
             else:
                 raise ValueError(
                     "Argument must be a filename if h5py does not have MPI support"

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -512,7 +512,6 @@ class MPIArray(np.ndarray):
         # Read using MPI-IO if possible
         if fh.is_mpi:
             with dset.collective:
-                print("using mpi-io")
                 dist_arr[:] = dset[start:end]
         else:
             dist_arr[:] = dset[start:end]

--- a/caput/tests/test_memh5_parallel.py
+++ b/caput/tests/test_memh5_parallel.py
@@ -64,12 +64,12 @@ class TestMemGroupDistributed(unittest.TestCase):
         # Create an empty array with a specified shape
         pdset = g.create_dataset('parallel_data', shape=(size, 10), dtype=np.float64, distributed=True, distributed_axis=0)
         pdset[:] = rank
-        pdset.attrs['rank'] = rank
+        pdset.attrs['const'] = 17
 
         # Create an empty array with a specified shape
         sdset = g.create_dataset('serial_data', shape=(size*5, 10), dtype=np.float64)
         sdset[:] = rank
-        sdset.attrs['rank'] = rank
+        sdset.attrs['const'] = 18
 
         # Create nested groups
         g.create_group('hello/world')
@@ -80,15 +80,15 @@ class TestMemGroupDistributed(unittest.TestCase):
         with h5py.File(self.fname, 'r') as f:
 
             # Test that the file attributes are correct
-            self.assertTrue(f['parallel_data'].attrs['rank'] == 0)
+            self.assertTrue(f['parallel_data'].attrs['const'] == 17)
 
             # Test that the parallel dataset has been written correctly
             self.assertTrue((f['parallel_data'][:, 0] == np.arange(size)).all())
-            self.assertTrue(f['parallel_data'].attrs['rank'] == 0)
+            self.assertTrue(f['parallel_data'].attrs['const'] == 17)
 
             # Test that the common dataset has been written correctly (i.e. by rank=0)
             self.assertTrue((f['serial_data'][:] == 0).all())
-            self.assertTrue(f['serial_data'].attrs['rank'] == 0)
+            self.assertTrue(f['serial_data'].attrs['const'] == 18)
 
             # Check group structure is correct
             self.assertIn('hello', f)
@@ -108,8 +108,8 @@ class TestMemGroupDistributed(unittest.TestCase):
         self.assertIn('world', g2['hello'])
 
         # Check the attributes
-        self.assertTrue(g2['parallel_data'].attrs['rank'] == 0)
-        self.assertTrue(g2['serial_data'].attrs['rank'] == 0)
+        self.assertTrue(g2['parallel_data'].attrs['const'] == 17)
+        self.assertTrue(g2['serial_data'].attrs['const'] == 18)
 
     def tearDown(self):
         if rank == 0:


### PR DESCRIPTION
Uses HDF5/h5py parallel features to allow concurrent writing of datasets and
more efficient reading.

I have noticed some slight issues using h5py collective parallel routines in
test examples when using OMPIO is the MPI-IO implementation (ROMIO did not seem
to have this problem). At the moment I'm still investigating. When cedar comes
back I'll try to test whether this is a reasonable concern.