### PR TITLE
build: Enforce numpy>=1.16 everywhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython', 'future', 'numpy==1.15.1']
+requires = ['setuptools', 'wheel', 'Cython', 'future', 'numpy>=1.16']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.16
 h5py
 PyYAML
 skyfield>=1.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools.extension import Extension
 from caput import __version__
 
 
-REQUIRES = ['numpy>=1.16', 'h5py', 'PyYAML', 'cython']
+REQUIRES = ['numpy>=1.16', 'h5py', 'PyYAML', 'cython', 'future']
 
 # Don't install requirements if on ReadTheDocs build system.
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools.extension import Extension
 from caput import __version__
 
 
-REQUIRES = ['numpy', 'h5py', 'PyYAML', 'cython']
+REQUIRES = ['numpy>=1.16', 'h5py', 'PyYAML', 'cython']
 
 # Don't install requirements if on ReadTheDocs build system.
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'


### PR DESCRIPTION
If we really need to maintain three different lists of requirements, let's at least make them all the same.

`numpy-1.16` has a forwards-incompatible ABI change which seems to be causing grief (see numpy/numpy#12785), but if we enforce a NumPy after the change, we should be good, hopefully.

Closes #87