### PR TITLE
ci: move installing doc/reauirements.txt to docbuild check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# editor rubble
+*~
+.*.swp
+
 *.py[cod]
 
 # C extensions

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
     - "pip install -r requirements.txt"
     - "pip install mpi4py"
     - "python setup.py develop"
-    - "pip install -r doc/requirements.txt"
 
 jobs:
     include:
@@ -30,6 +29,7 @@ jobs:
         - stage: doc build
           python: 3.7
           script:
+            - "pip install -r doc/requirements.txt"
             - "sphinx-build -b html doc/ doc/_build/html"
 
 script:


### PR DESCRIPTION
The contents of doc/requirements.txt are not typically installed when caput is deployed.  We should remove it from the blanket install rules to avoid masking missing items in ./requirements.txt which happen to be listed in doc/requirements.txt.