### PR TITLE
Use copyfile instead of copy

### DIFF
--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -181,7 +181,7 @@ def queue(configfile, submit=False):
     sfile = fixpath(configfile)
     dfile = fixpath(join(jobdir, "config.yaml"))
     if sfile != dfile:
-        shutil.copy(sfile, dfile)
+        shutil.copyfile(sfile, dfile)
 
     # Set up virtualenv
     if "venv" in rconf:


### PR DESCRIPTION
Sajan ran into an issue running the holography pipeline where it would fail to copy the config file to the job directory because of permissions, even though he had group write access to the directory and file. This is because there was an existing config file there owned by my user, and `shutil.copy` modifies file metadata as well as contents. This is not allowed on a file owned by another user. Using `shutil.copyfile` should resolve this.