### PR TITLE
fix(tod): fixes bug where `data` variable overwritten

### DIFF
--- a/caput/tod.py
+++ b/caput/tod.py
@@ -634,12 +634,12 @@ def _copy_non_time_data(
             ):
                 to_dataset_names.append(entry.name)
             elif out is not None:
-                data = (
+                arr = (
                     memh5.ensure_unicode(entry.data)
                     if convert_dataset_strings
                     else entry.data
                 )
-                out.create_dataset(key, shape=entry.shape, dtype=entry.dtype, data=data)
+                out.create_dataset(key, shape=entry.shape, dtype=entry.dtype, data=arr)
                 memh5.copyattrs(
                     entry.attrs, out[key].attrs, convert_strings=convert_dataset_strings
                 )


### PR DESCRIPTION
Fixes bug in `_copy_non_time_data` where the `data` variable
was being over written if a dataset without a time axis was
encountered.

Bug introduced in commit 249face8d4e0ab38e91507c0724606687d8515c8.