### PR TITLE
Bug fixed on variable name: pro_argspec.keywords to pro_argspec.varkw

### DIFF
--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -1003,7 +1003,7 @@ class _OneAndOne(TaskBase):
         if (
             pro_argspec.varargs
             or pro_argspec.varkw
-            or pro.argspec.kwonlyargs
+            or pro_argspec.kwonlyargs
             or pro_argspec.defaults
         ):
             msg = (

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -1002,7 +1002,7 @@ class _OneAndOne(TaskBase):
             raise PipelineConfigError(msg)
         if (
             pro_argspec.varargs
-            or pro_argspec.keywords
+            or pro_argspec.varkw
             or pro.argspec.kwonlyargs
             or pro_argspec.defaults
         ):


### PR DESCRIPTION
A property of misc.getfullargspec was misspelled, I renamed following the suggestion of @jrs65 