### PR TITLE
feat(pipeline): improve log level config

### DIFF
--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -34,18 +34,22 @@ def cli():
 @click.option(
     "--loglevel",
     type=click.Choice(
-        ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"], case_sensitive=False
+        ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "CONFIG"],
+        case_sensitive=False,
     ),
-    default="INFO",
-    help="Logging level.",
+    default="CONFIG",
+    help="Logging level (deprecated, use the config instead).",
 )
 def run(configfile, loglevel):
     """Run a pipeline immediately from the given CONFIGFILE."""
     from caput.pipeline import Manager
-    import logging
 
-    level = getattr(logging, loglevel.upper())
-    logging.basicConfig(level=level)
+    import warnings
+
+    if loglevel != "CONFIG":
+        warnings.warn(
+            "--loglevel is deprecated, use the config file instead", DeprecationWarning
+        )
 
     P = Manager.from_yaml_file(configfile)
     P.run()

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1,0 +1,43 @@
+.. _config:
+
+Configuration
+=============
+
+General options
+---------------
+
+
+Pipeline
+--------
+
+Logging
+.......
+The log levels can be configured in multiple ways:
+
+- Use the `logging` section directly in the pipeline blog to define the root log level with either
+  `DEBUG`, `INFO`, `WARNING` or `ERROR`. You can also also set log levels for single modules here
+  and may add a root log level with the key `"root"`. The default is `{"root": "WARNING"}`
+
+Examples:
+
+::
+
+  pipeline:
+    logging:
+      root: DEBUG
+      annoying.module: INFO
+
+would show `DEBUG` messages for everything, but `INFO` only for a module called `annoying.module`.
+
+::
+
+  pipeline:
+    logging: ERROR
+
+would reduce all loggin to `ERROR` messages.
+
+- Set the `log_level` parameter of any task of type
+  `draco.core.task.LoggedTask <https://github.com/radiocosmology/draco/blob/master/draco/core/task.py>`_.
+
+- Further filter logging by MPI ranks using
+  `draco.core.task.SetMPILogging <https://github.com/radiocosmology/draco/blob/master/draco/core/task.py>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,6 +32,23 @@ Installation
 caput depends on h5py_, numpy_ and PyYAML_. For full functionality it also
 requires click_, mpi4py_ and Skyfield_.
 
+
+Configuration
+_____________
+
+The caput pipeline runner script accepts a YAML file for configuration. The structure of this file
+is documented in :ref:`config`.
+
+
+Index
+-----
+
+.. toctree::
+   :maxdepth: 2
+
+   config
+
+
 Modules
 -------
 


### PR DESCRIPTION
- Allow to pass a dict to config section 'pipeline/logging' that defines a
log level per module.
- Add option 'logging' to task config that defines the loglevel for the
module the task uses (takes priority over the above).

Fixes https://github.com/chime-experiment/Pipeline/issues/36