### PR TITLE
fix(mpiarray): bug when selecting data during distributed read

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,9 @@ jobs:
       run: |
         mpirun -np 4 pytest caput/tests/test_memh5_parallel.py
         mpirun -np 4 pytest caput/tests/test_mpiarray.py
+        mpirun -np 1 pytest caput/tests/test_selection_parallel.py
+        mpirun -np 2 pytest caput/tests/test_selection_parallel.py
+        mpirun -np 4 pytest caput/tests/test_selection_parallel.py
 
   build-docs:
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1059,13 +1059,20 @@ def _len_slice(slice_, n):
 
 def _reslice(slice_, n, subslice):
     # For a slice along an axis of length n, return the slice that would select the
-    # start:end elements of the final array
+    # slice(start, end) elements of the final array.
+    #
+    # In other words find a single slice that has the same affect as application of two successive
+    # slices
     dstart, dstop, dstep = slice_.indices(n)
 
     if subslice.step is not None and subslice.step > 1:
         raise ValueError("stride > 1 not supported. subslice: %s" % subslice)
 
-    return slice(dstart + subslice.start * dstep, dstart + subslice.stop * dstep, dstep)
+    return slice(
+        dstart + subslice.start * dstep,
+        min(dstart + subslice.stop * dstep, dstop),
+        dstep,
+    )
 
 
 def _expand_sel(sel, naxis):

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -656,7 +656,7 @@ class MPIArray(np.ndarray):
             # Loop over partitions of the IO and perform them
             for part in partitions:
                 islice, fslice = _partition_sel(
-                    sel, split_axis, gshape[split_axis], part
+                    sel, split_axis, dshape[split_axis], part
                 )
                 dist_arr[fslice] = dset[islice]
 

--- a/caput/tests/test_selection.py
+++ b/caput/tests/test_selection.py
@@ -1,3 +1,10 @@
+"""Serial version of the selection tests."""
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
+# === End Python 2/3 compatibility
 from caput.memh5 import MemGroup
 
 import pytest
@@ -42,13 +49,5 @@ def test_H5FileSelect(container_on_disk):
     """Tests that makes hdf5 objects and tests selecting on their axes."""
 
     m = MemGroup.from_hdf5(container_on_disk, selections=sel)
-    assert np.all(m["dset1"][:] == dset1[(fsel, isel, slice(None))])
-    assert np.all(m["dset2"][:] == dset2[(fsel, slice(None))])
-
-
-def test_H5FileSelect_distributed(container_on_disk):
-    """Load H5 into parallel container while down-selecting axes."""
-
-    m = MemGroup.from_hdf5(container_on_disk, selections=sel, distributed=True)
     assert np.all(m["dset1"][:] == dset1[(fsel, isel, slice(None))])
     assert np.all(m["dset2"][:] == dset2[(fsel, slice(None))])

--- a/caput/tests/test_selection_parallel.py
+++ b/caput/tests/test_selection_parallel.py
@@ -1,0 +1,98 @@
+"""Parallel version of the selection tests.
+
+Needs to be run on 1, 2 or 4 MPI processes.
+"""
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
+# === End Python 2/3 compatibility
+from caput import mpiutil, mpiarray
+from caput.memh5 import MemGroup
+
+import pytest
+import glob
+import numpy as np
+import os
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+
+len_axis = 8
+
+dset1 = np.arange(len_axis * len_axis * len_axis)
+dset1 = dset1.reshape((len_axis, len_axis, len_axis))
+
+dset2 = np.arange(len_axis * len_axis)
+dset2 = dset2.reshape((len_axis, len_axis))
+
+freqs = np.arange(len_axis)
+inputs = np.arange(len_axis)
+ra = np.arange(len_axis)
+
+
+@pytest.fixture(scope="module")
+def container_on_disk():
+
+    fname = "tmp_test_memh5_select_parallel.h5"
+
+    if comm.rank == 0:
+        m1 = mpiarray.MPIArray.wrap(dset1, axis=0, comm=MPI.COMM_SELF)
+        m2 = mpiarray.MPIArray.wrap(dset2, axis=0, comm=MPI.COMM_SELF)
+        container = MemGroup(distributed=True, comm=MPI.COMM_SELF)
+        container.create_dataset("dset1", data=m1, distributed=True)
+        container.create_dataset("dset2", data=m2, distributed=True)
+        container.to_hdf5(fname)
+
+    comm.Barrier()
+
+    yield fname
+
+    comm.Barrier()
+
+    # tear down
+
+    if comm.rank == 0:
+        file_names = glob.glob(fname + "*")
+        for fname in file_names:
+            os.remove(fname)
+
+
+@pytest.mark.parametrize("fsel", [slice(1, 8, 2), slice(5, 8, 2)])
+@pytest.mark.parametrize("isel", [slice(1, 4), slice(5, 8, 2)])
+def test_H5FileSelect_distributed(container_on_disk, fsel, isel):
+    """Load H5 into parallel container while down-selecting axes."""
+
+    sel = {"dset1": (fsel, isel, slice(None)), "dset2": (fsel, slice(None))}
+
+    # Tests are designed to run for 1, 2 or 4 processes
+    assert 4 % comm.size == 0
+
+    m = MemGroup.from_hdf5(
+        container_on_disk, selections=sel, distributed=True, comm=comm
+    )
+
+    d1 = dset1[(fsel, isel, slice(None))]
+    d2 = dset2[(fsel, slice(None))]
+
+    n, s, e = mpiutil.split_local(d1.shape[0], comm=comm)
+
+    dslice = slice(s, e)
+
+    # For debugging...
+    # Need to dereference datasets as this is collective
+    # md1 = m["dset1"][:]
+    # md2 = m["dset2"][:]
+    # for ri in range(comm.size):
+    #     if ri == comm.rank:
+    #         print(comm.rank)
+    #         print(md1.shape, d1.shape, d1[dslice].shape)
+    #         print(md1[0, :2, :2] if md1.size else "Empty")
+    #         print(d1[dslice][0, :2, :2] if d1[dslice].size else "Empty")
+    #         print()
+    #     comm.Barrier()
+
+    assert np.all(m["dset1"][:] == d1[dslice])
+    assert np.all(m["dset2"][:] == d2[dslice])


### PR DESCRIPTION
Currently MPIArray.from_hdf5 uses the shape of the post-selection dataset
to form each nodes selection.  This results in reading in the wrong
data from disk for distributed datasets.  The fix uses the shape of the
dataset pre-selection.