### PR TITLE
Fix lock_file() behavior

### DIFF
--- a/caput/misc.py
+++ b/caput/misc.py
@@ -167,7 +167,9 @@ class lock_file(object):
             raise ValueError("comm argument does not seem to be an MPI communicator.")
 
         self.name = name
-        self.rank0 = mpiutil.rank0 if comm is None else comm.rank == 0
+        # If comm not specified, set internal rank0 marker to True,
+        # so that rank>0 tasks can open their own files
+        self.rank0 = True if comm is None else comm.rank == 0
         self.preserve = preserve
 
     def __enter__(self):

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -1399,7 +1399,7 @@ class H5IOMixin(object):
                 out_copy = memh5.MemGroup.from_hdf5(output)
 
                 # Lock file as we write
-                with misc.lock_file(filename) as fn:
+                with misc.lock_file(filename, comm=out_copy.comm) as fn:
                     out_copy.to_hdf5(fn, mode="w")
 
 


### PR DESCRIPTION
This changes the behavior of `misc.lock_file()` to match its docstring: specifically, if no `comm` argument is specified, the file is opened and closed by the current rank, while if `comm` is specified, only rank 0 does the opening and closing.

I searched for `lock_file` in the relevant repos in radiocosmology and chime-experiment, and the only place where `lock_file()` is actually used is in `caput.pipeline`, and I modified the relevant call to specify a `comm` argument so that the previous behavior is preserved.