### PR TITLE
Pipeline script linting

### DIFF
--- a/caput/config.py
+++ b/caput/config.py
@@ -140,6 +140,11 @@ class Property(object):
             The parent object of the Property that we want to update.
         config : dict
             Dictionary of configuration values.
+
+        Raises
+        ------
+        ConfigError
+            If there was an error in the config dict.
         """
 
         self._set_propname(obj)
@@ -148,7 +153,12 @@ class Property(object):
             self.key = self.propname
 
         if self.key in config:
-            val = self.proptype(config[self.key])
+            try:
+                val = self.proptype(config[self.key])
+            except TypeError as e:
+                raise ConfigError(
+                    "Can't read value of '%s' as %s: %s" % (self.key, self.proptype, e)
+                )
             obj.__dict__[self.propname] = val
 
     def _set_propname(self, obj):

--- a/caput/config.py
+++ b/caput/config.py
@@ -473,6 +473,11 @@ def logging_config(default={}):
         checked_config = {}
         loglevels = ["DEBUG", "INFO", "WARNING", "ERROR", "NOTSET"]
         for key, level in config.items():
+
+            # ignore hint at yaml file line number
+            if key == "__line__":
+                continue
+
             level = level.upper()
             if level not in loglevels:
                 raise ValueError(

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -698,7 +698,12 @@ class Manager(config.Reader):
         }
 
         # Create and configure the task instance
-        task = task_cls._from_config(task_params)
+        try:
+            task = task_cls._from_config(task_params)
+        except Exception as e:
+            raise PipelineConfigError(
+                "Failed instanciating %s from config: %s" % (task_cls, e)
+            )
 
         return task, key_spec
 

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -749,7 +749,7 @@ class Manager(config.Reader):
                 out_keys = [t._out_keys for t in self.tasks if t != task]
                 out_keys = [item for sublist in out_keys for item in sublist]
 
-                if isinstance(value, str):
+                if not isinstance(value, list):
                     value = [value]
                 for v in value:
                     if v not in out_keys:

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -628,7 +628,7 @@ class Manager(config.Reader):
                     in_=key_spec.get("in", None),
                     out=key_spec.get("out", None),
                 )
-            except PipelineConfigError as e:
+            except (PipelineConfigError, config.ConfigError) as e:
                 msg = "Setting up task {} caused an error - {}".format(ii, str(e))
                 raise_from(PipelineConfigError(msg), e)
 

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -282,7 +282,7 @@ But this is what it would produce otherwise::
     Spam and ostrich eggs.
     Finished PrintEggs.
 
-Notice that :meth:`DoNothing.next` is nerver called, since the pipeline never
+Notice that :meth:`DoNothing.next` is never called, since the pipeline never
 generates its input, 'non_existent_data_product'.  Once everything before
 :class:`DoNothing` has been executed the pipeline notices that there is no
 opertunity for 'non_existent_data_product' to be generated and forces

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -651,7 +651,8 @@ class Manager(config.Reader):
                     e,
                 )
 
-    def _validate_task(self, task, in_, requires, all_out_values):
+    @staticmethod
+    def _validate_task(task, in_, requires, all_out_values):
         # Make sure this tasks in/requires values have corresponding out keys from another task
         for key, value in (["in", in_], ["requires", requires]):
             if value is not None:

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -512,8 +512,13 @@ class Manager(config.Reader):
         self: Pipeline object
         """
 
-        with open(file_name) as f:
-            yaml_doc = f.read()
+        try:
+            with open(file_name) as f:
+                yaml_doc = f.read()
+        except TypeError as e:
+            raise PipelineConfigError(
+                "Unable to open yaml file ({}): {}".format(file_name, e)
+            )
         return cls.from_yaml_str(yaml_doc)
 
     @classmethod

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -260,21 +260,27 @@ illustrates these rules in a pipeline with a slightly more non-trivial flow.
 ... no_params: {}
 ... '''
 
->>> Manager.from_yaml_str(new_spam_config).run()
-Setting up GetEggs.
-Setting up CookEggs.
-Setting up DoNothing.
-Setting up PrintEggs.
-Cooking fried green eggs.
-Cooking fried duck eggs.
-Cooking fried ostrich eggs.
-Finished GetEggs.
-Finished CookEggs.
-Finished DoNothing.
-Spam and green eggs.
-Spam and duck eggs.
-Spam and ostrich eggs.
-Finished PrintEggs.
+The following would error, because the pipeline config is checked for errors, like an 'in' parameter without a
+corresponding 'out'::
+
+    Manager.from_yaml_str(new_spam_config).run()
+
+But this is what it would produce otherwise::
+
+    Setting up GetEggs.
+    Setting up CookEggs.
+    Setting up DoNothing.
+    Setting up PrintEggs.
+    Cooking fried green eggs.
+    Cooking fried duck eggs.
+    Cooking fried ostrich eggs.
+    Finished GetEggs.
+    Finished CookEggs.
+    Finished DoNothing.
+    Spam and green eggs.
+    Spam and duck eggs.
+    Spam and ostrich eggs.
+    Finished PrintEggs.
 
 Notice that :meth:`DoNothing.next` is nerver called, since the pipeline never
 generates its input, 'non_existent_data_product'.  Once everything before

--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -36,6 +36,7 @@ def cli():
 )
 def lint_config(configfile):
     """Test a pipeline for errors without running it."""
+    from caput.config import CaputConfigError
     from caput.pipeline import Manager
 
     # nargs=-1 packs multiple arguments (or glob patterns) into tuples
@@ -46,7 +47,7 @@ def lint_config(configfile):
 
         try:
             Manager.from_yaml_file(f)
-        except Exception as e:
+        except CaputConfigError as e:
             click.echo(
                 "Found at least one error in '{}'.\n"
                 "Fix and run again to find more problems.".format(f)

--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -44,7 +44,7 @@ def lint_config(configfile):
         load_venv(f)
 
         try:
-            Manager.from_yaml_file(f)
+            Manager.from_yaml_file(f, lint=True)
         except CaputConfigError as e:
             click.echo(
                 "Found at least one error in '{}'.\n"
@@ -231,7 +231,7 @@ def queue(configfile, submit=False, lint=True):
     if lint:
         from caput.pipeline import Manager
 
-        Manager.from_yaml_file(configfile)
+        Manager.from_yaml_file(configfile, lint=True)
 
     with open(configfile, "r") as f:
         yconf = yaml.safe_load(f)

--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -12,8 +12,6 @@ from os.path import (
 import click
 import sys
 
-from pathlib import Path
-
 products = None
 
 
@@ -70,13 +68,16 @@ def load_venv(configfile):
 
     click.echo("Activating '{}'...".format(venv_path))
 
-    base = Path(venv_path).absolute()
+    # TODO: python2 - use pathlib
+    import os.path
+
+    base = os.path.abspath(venv_path)
     if not base.exists():
         click.echo("Path defined in 'cluster'/'venv' doesn't exist ({})".format(base))
         sys.exit(1)
 
-    site_packages = Path(
-        base / "lib" / "python{}".format(sys.version[:3]) / "site-packages"
+    site_packages = os.path.join(
+        base, "lib", "python{}".format(sys.version[:3]), "site-packages"
     )
     prev_sys_path = list(sys.path)
 

--- a/caput/tests/test_config.py
+++ b/caput/tests/test_config.py
@@ -78,21 +78,21 @@ class TestConfig(unittest.TestCase):
 
         lt = ListTypeTests()
 
-        with self.assertRaises(config.ConfigError):
+        with self.assertRaises(config.CaputConfigError):
             lt.read_config({"list_max_length": [1, 3, 4]})
 
         # Should work fine
         lt = ListTypeTests()
         lt.read_config({"list_max_length": [1, 2]})
 
-        with self.assertRaises(config.ConfigError):
+        with self.assertRaises(config.CaputConfigError):
             lt.read_config({"list_exact_length": [3]})
 
         # Work should fine
         lt = ListTypeTests()
         lt.read_config({"list_exact_length": [1, 2]})
 
-        with self.assertRaises(config.ConfigError):
+        with self.assertRaises(config.CaputConfigError):
             lt.read_config({"list_type": ["hello"]})
 
         # Work should fine

--- a/caput/tests/test_config.py
+++ b/caput/tests/test_config.py
@@ -78,21 +78,21 @@ class TestConfig(unittest.TestCase):
 
         lt = ListTypeTests()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(config.ConfigError):
             lt.read_config({"list_max_length": [1, 3, 4]})
 
         # Should work fine
         lt = ListTypeTests()
         lt.read_config({"list_max_length": [1, 2]})
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(config.ConfigError):
             lt.read_config({"list_exact_length": [3]})
 
         # Work should fine
         lt = ListTypeTests()
         lt.read_config({"list_exact_length": [1, 2]})
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(config.ConfigError):
             lt.read_config({"list_type": ["hello"]})
 
         # Work should fine

--- a/caput/tests/test_lint.py
+++ b/caput/tests/test_lint.py
@@ -1,0 +1,98 @@
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
+# === End Python 2/3 compatibility
+
+import pytest
+import tempfile
+import yaml
+
+from click.testing import CliRunner
+
+from caput.config import Property
+from caput.pipeline import TaskBase
+from caput.scripts import runner as caput_script
+
+
+class DoNothing(TaskBase):
+    pass
+
+
+class DoNothing2(DoNothing):
+    a_list = Property(proptype=list)
+
+
+@pytest.fixture()
+def simple_config():
+    yield {
+        "pipeline": {
+            "tasks": [
+                {
+                    "type": "caput.tests.test_lint.DoNothing",
+                    "out": "out1",
+                },
+                {
+                    "type": "caput.tests.test_lint.DoNothing",
+                    "out": "out2",
+                    "in": "out1",
+                },
+                {
+                    "type": "caput.tests.test_lint.DoNothing2",
+                    "in": "out2",
+                    "out": "out3",
+                    "requires": "out1",
+                    "params": {
+                        "a_list": [1],
+                    },
+                },
+            ]
+        }
+    }
+
+
+def write_to_file(config_json):
+    temp = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
+    temp.write(yaml.dump(config_json))
+    temp.flush()
+    return temp.name
+
+
+def test_load_yaml(simple_config):
+    test_runner = CliRunner()
+    config_file = write_to_file(simple_config)
+    result = test_runner.invoke(caput_script.lint_config, [config_file])
+    assert result.exit_code == 0
+
+
+def test_unknown_task(simple_config):
+    test_runner = CliRunner()
+    simple_config["pipeline"]["tasks"][0]["type"] = "what.was.the.name.of.my.Task"
+    config_file = write_to_file(simple_config)
+    result = test_runner.invoke(caput_script.lint_config, [config_file])
+    assert result.exit_code != 0
+
+
+def test_wrong_type(simple_config):
+    test_runner = CliRunner()
+    simple_config["pipeline"]["tasks"][2]["params"]["a_list"] = 1
+    config_file = write_to_file(simple_config)
+    result = test_runner.invoke(caput_script.lint_config, [config_file])
+    assert result.exit_code != 0
+
+
+def test_lonely_in(simple_config):
+    test_runner = CliRunner()
+    simple_config["pipeline"]["tasks"][2]["in"] = "foo"
+    config_file = write_to_file(simple_config)
+    result = test_runner.invoke(caput_script.lint_config, [config_file])
+    assert result.exit_code != 0
+
+
+def test_lonely_requires(simple_config):
+    test_runner = CliRunner()
+    simple_config["pipeline"]["tasks"][2]["requires"] = "bar"
+    config_file = write_to_file(simple_config)
+    result = test_runner.invoke(caput_script.lint_config, [config_file])
+    assert result.exit_code != 0

--- a/caput/tests/test_lint.py
+++ b/caput/tests/test_lint.py
@@ -54,7 +54,7 @@ def simple_config():
 
 def write_to_file(config_json):
     temp = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
-    temp.write(yaml.dump(config_json))
+    yaml.safe_dump(config_json, temp, encoding="utf-8")
     temp.flush()
     return temp.name
 

--- a/caput/tests/test_metadata.py
+++ b/caput/tests/test_metadata.py
@@ -26,8 +26,12 @@ class TestConfig(unittest.TestCase):
         self.assertIn("pipeline_config", man.all_tasks_params)
 
         self.assertDictEqual(man.all_tasks_params["versions"], {})
+        # remove line numbers
+        pipeline_config = man.all_tasks_params["pipeline_config"]
+        del pipeline_config["__line__"]
+        del pipeline_config["pipeline"]["__line__"]
         self.assertDictEqual(
-            man.all_tasks_params["pipeline_config"],
+            pipeline_config,
             yaml.load(testconfig, Loader=yaml.SafeLoader),
         )
 
@@ -50,8 +54,13 @@ class TestConfig(unittest.TestCase):
             man.all_tasks_params["versions"],
             {"numpy": numpy.__version__, "caput": caput.__version__},
         )
+
+        # remove line numbers
+        pipeline_config = man.all_tasks_params["pipeline_config"]
+        del pipeline_config["__line__"]
+        del pipeline_config["pipeline"]["__line__"]
         self.assertDictEqual(
-            man.all_tasks_params["pipeline_config"],
+            pipeline_config,
             yaml.load(testconfig, Loader=yaml.SafeLoader),
         )
 


### PR DESCRIPTION
### Examples:

**Value of `requires` has no corresponding `out`:**
```
pipeline:
  tasks:
  - in: input_files
    out: siderealday
    type: caput.tests.test_lint.DoNothing
  - in: siderealday
    out: tstream
    params:
      a_list:
      - 1
    requires: input_files
    type: caput.tests.test_lint.DoNothing2
```
output:
```
caput.pipeline.PipelineConfigError: Setting up task 0 caused an error - Value 'in' for task <class 'caput.tests.test_lint.DoNothing'> has no corresponding 'out' from another task (Value input_files is not in []).
```

**Input file doesn't exist:**
```
pipeline:
  tasks:
  - out: input_files
    params:
      files: /this/does/not/exist.h5
    type: draco.core.io.LoadFilesFromParams
  - in: input_files
    out: siderealday
    type: ch_pipeline.analysis.sidereal.SiderealGrouper
  - in: siderealday
    out: maskedday
    params:
      output_name: rfi_filtered.h5
      save: true
    requires: input_files
    type: ch_pipeline.analysis.flagging.RFIFilter
  - in: maskedday
    out: tstream
    params:
      flag_type:
      - globalflag
      - bad_calibration_fpga_restart
      period: 2
      phase:
      - 1
    type: ch_pipeline.analysis.calibration.NoiseSourceFold
```
output:
```
caput.pipeline.PipelineConfigError: Setting up task 0 caused an error - Failed instanciating <class 'draco.core.io.LoadFilesFromParams'> from config: File not found: /this/does/not/exist.h5
```

**Task doesn't exist**
```
pipeline:
  tasks:
  - out: input_files
    params:
      files: testdata / *.h5
    type: draco.core.io.OupsTypo
  - in: input_files
    out: siderealday
    type: ch_pipeline.analysis.sidereal.SiderealGrouper
```
output:
```
caput.pipeline.PipelineConfigError: Setting up task 0 caused an error - Loading task 'draco.core.io.OupsTypo' caused error - AttributeError: module 'draco.core.io' has no attribute 'OupsTypo'
```