### PR TITLE
fix(transit_times): Handle small intervals better

### DIFF
--- a/caput/tests/test_time.py
+++ b/caput/tests/test_time.py
@@ -14,7 +14,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 from skyfield import earthlib, api
-from pytest import approx
+from pytest import approx, raises
 
 from caput import time as ctime
 
@@ -421,6 +421,21 @@ def test_transit_times(chime, eph):
     # attempts to use the new routines, and seems reasonable enough that I'm not going
     # to track down the difference
     assert times == approx(precalc_times, abs=2)
+
+    # Test automatic step calculation
+    small_times = chime.transit_times(
+        eph["sun"], precalc_times[0] - 300, precalc_times[0] + 60
+    )
+
+    assert small_times == approx(precalc_times[:1], abs=2)
+
+    # end <= start raises ValueError
+    with raises(ValueError):
+        chime.transit_times(eph["sun"], dte, dts)
+
+    # step >= interval raises ValueError
+    with raises(ValueError):
+        chime.transit_times(eph["sun"], dts, dte, step=10)
 
 
 def test_rise_set_times(chime, eph):


### PR DESCRIPTION
If `step` is not provided, `transit_times` will use a default initial search step of one fifth of the search interval, or 0.2 days, whichever is smaller.

Also:
 - raises `ValueError` if the initial search step is larger than the search interval, in which case no transit will ever be found.
 - raises `ValueError` if the search interval is non-positive. Without this, `NumPy` instead raises `ValueError` with a cryptic message complaining about negative array length)

Closes #149 