### PR TITLE
fix(time.Observer.transit_times): Use sidereal day.

### DIFF
--- a/caput/time.py
+++ b/caput/time.py
@@ -584,7 +584,7 @@ class Observer(object):
         # Get the ends of the search interval
         t0 = ensure_unix(t0)
         if t1 is None:
-            t1 = t0 + 24 * 3600.0
+            t1 = t0 + 24 * 3600.0 * STELLAR_S
         else:
             t1 = ensure_unix(t1)
             if t1 <= t0:


### PR DESCRIPTION
Use the sidereal second to set the end time to one sidereal day
later if not specified. Otherwise you get two transit times if
t0 is within a few minutes of transit.

This seemed like unexpected behaviour to me.