### PR TITLE
chore(pipeline): add deprecated PipelineConfigError

### DIFF
--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -366,6 +366,19 @@ local_tasks = {}
 # ----------
 
 
+class PipelineConfigError(config.CaputConfigError):
+    """Deprecated. Raised when there is an error setting up a pipeline."""
+
+    def __init__(self, message):
+        warnings.warn(
+            "caput.pipeline.PipelineConfigError is deprecated. It will get removed in December 2021. "
+            "Use caput.config.CaputConfigError instead.",
+            DeprecationWarning,
+            2,
+        )
+        super(PipelineConfigError, self).__init__(message)
+
+
 class PipelineRuntimeError(Exception):
     """Raised when there is a pipeline related error at runtime."""
 


### PR DESCRIPTION
PipelineConfigError was removed in 8f22399 but was still used outside of
caput. This adds a deprecated version.

BREAKING CHANGE: caput.pipeline.PipelineConfigError is deprecated and
will be removed in July 2021. Use caput.config.CaputConfigError instead.

Closes #155 