### PR TITLE
feat(mpiarray): ufunc, __array_finalize__, and  __getitem__ handling for MPIArray

### DIFF
--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -55,7 +55,8 @@ Its behaviour changes depending on the exact slice it gets:
 It's important to note that it never communicates data between ranks. It only
 ever operates on data held on the current rank.
 
-Example
+Global Slicing Examples
+-----------------------
 
 Here is an example of this in action::
 
@@ -98,7 +99,8 @@ Direct Slicing
 This can be used for both fetching and assignment. It is recommended
 to only index into the non-parallel axis or to do a full slice `[:]`.
 
-Behaviour
+Direct Slicing Behaviour
+------------------------
 
 - A full slice `[:]` will return a :class:`MPIArray` on fetching, with
   identical properties to the original array.
@@ -108,7 +110,8 @@ Behaviour
 - Any indexing into the parallel axis will result into a local index on each rank,
   returning a regular `numpy` array.
 
-Example
+Direct Slicing Examples
+-----------------------
 
     import numpy as np
     from caput import mpiarray, mpiutil
@@ -137,12 +140,14 @@ In NumPy, universal functions (or ufuncs) are functions that operate on ndarrays
 in an element-by-element fashion. :class:`MPIArray` supports all ufunc calculations,
 except along the parallel axis.
 
-Requirements
+ufunc Requirements
+------------------
 
 - All input :class:`MPIArray` *must* be distributed along the same axis.
 - If you pass a kwarg `axis` to the ufunc, it must not be the parallel axis.
 
-Behaviour
+ufunc Behaviour
+---------------
 
 - If no output are provided, the results are converted back to MPIArrays. The new array
   will either be parallel over the same axis as the input MPIArrays, or possibly one axis
@@ -152,7 +157,8 @@ Behaviour
   parallel across axis 0.
 - shape related attributes will be re-calculated
 
-Example
+ufunc Examples
+--------------
 
     import numpy as np
     from caput import mpiarray, mpiutil

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -253,13 +253,20 @@ class MPIArray(np.ndarray):
         if (dist_axis_index != slice(None, None, None)) and (
             dist_axis_index != slice(0, self.local_array.shape[self.axis], None)
         ):
+            import warnings
             if isinstance(dist_axis_index, int):
-                raise AxisException(
-                    "Cannot directly index distributed axis; use global_slice instead"
+                warnings.warn(
+                    "You are indexing directly into the distributed axis."
+                    "Returning a view into the local array."
+                    "Please use global_slice, or .local_array before indexing instead."
                 )
-            raise AxisException(
-                "Cannot directly sub-slice distributed axis; use global_slice instead"
-            )
+
+                return self.local_array.__getitem__(v)
+            warnings.warn(
+                    "You are directly sub-slicing the distributed axis."
+                    "Returning a view into the local array."
+                    "Please use global_slice, or .local_array before indexing.")
+            return self.local_array.__getitem__(v)
 
         # Figure out which is the axis number for the distributed axis after the slicing
         # by removing slice axes which are just ints from the mapping.

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -254,6 +254,7 @@ class MPIArray(np.ndarray):
             dist_axis_index != slice(0, self.local_array.shape[self.axis], None)
         ):
             import warnings
+
             if isinstance(dist_axis_index, int):
                 warnings.warn(
                     "You are indexing directly into the distributed axis."
@@ -263,9 +264,10 @@ class MPIArray(np.ndarray):
 
                 return self.local_array.__getitem__(v)
             warnings.warn(
-                    "You are directly sub-slicing the distributed axis."
-                    "Returning a view into the local array."
-                    "Please use global_slice, or .local_array before indexing.")
+                "You are directly sub-slicing the distributed axis."
+                "Returning a view into the local array."
+                "Please use global_slice, or .local_array before indexing."
+            )
             return self.local_array.__getitem__(v)
 
         # Figure out which is the axis number for the distributed axis after the slicing
@@ -1253,7 +1255,7 @@ class MPIArray(np.ndarray):
 
         # that ufunc was not implemented for ndarrays
         if results is NotImplemented:
-            raise NotImplemented
+            raise NotImplementedError
 
         # operation was performed in-place, so we can just return
         if method == "at":
@@ -1266,10 +1268,8 @@ class MPIArray(np.ndarray):
             # reduction methods eliminate axes, so the distributed axis
             # might need to be recalculated
             # except when the user explicitly specifies keepdims
-            if not kwargs.get("keepdims", False):
-                reduction_axis = kwargs["axis"]
-                if reduction_axis < dist_axis:
-                    dist_axis -= 1
+            if not kwargs.get("keepdims", False) and (kwargs["axis"] < dist_axis):
+                dist_axis -= 1
 
         ret = []
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -214,15 +214,17 @@ class _global_resolver:
             slobj = tuple(slice(None, None, None) if sl is None else sl for sl in slobj)
 
             # Return an MPIArray view
-            arr = self.array[slobj]
-
             # Figure out which is the distributed axis after the slicing, by
             # removing slice axes which are just ints from the mapping
             dist_axis = [
                 index for index, sl in enumerate(slobj) if not isinstance(sl, int)
             ].index(self.axis)
 
-            return MPIArray.wrap(arr, axis=dist_axis, comm=self.array._comm)
+            return MPIArray.wrap(
+                self.array.view(np.ndarray)[slobj],
+                axis=dist_axis,
+                comm=self.array._comm,
+            )
 
     def __setitem__(self, slobj, value):
 
@@ -1194,7 +1196,6 @@ class MPIArray(np.ndarray):
                 if reduction_axis < dist_axis:
                     dist_axis -= 1
 
-        # Wrapping the results back into MPIArrays, distributed across the appropriate axis
         ret = []
 
         for result, output in zip(results, outputs):

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1226,16 +1226,14 @@ class MPIArray(np.ndarray):
         if obj is None:
             return
 
-        # we are in a ufunc, rebuild the attributes from the original MPIArray
-        if isinstance(obj, MPIArray):
-            comm = getattr(obj, "comm", mpiutil.world)
-
-        if hasattr(obj, "axis"):
-            axis = obj.axis
-        else:
-            # in the middle of an np.ndarray.view()
-            # user will have to set the attributes themselves
+        if not isinstance(obj, MPIArray):
+            # in the middle of an np.ndarray.view() in the wrap()
             return
+
+        # we are in a slice, rebuild the attributes from the original MPIArray
+        comm = getattr(obj, "comm", mpiutil.world)
+
+        axis = obj.axis
 
         # Get shape and offset
         lshape = self.shape

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1233,7 +1233,9 @@ class MPIArray(np.ndarray):
         if hasattr(obj, "axis"):
             axis = obj.axis
         else:
-            raise Exception("Cannot construct output axis")
+            # in the middle of an np.ndarray.view()
+            # user will have to set the attributes themselves
+            return
 
         # Get shape and offset
         lshape = self.shape

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -844,6 +844,40 @@ class MPIArray(np.ndarray):
 
         return dist_arr
 
+    def allreduce(self, op=None):
+        """Perform MPI reduction operation `op` by pickling local array.
+
+        Return results for all ranks.
+
+        Parameters
+        ----------
+        op : MPI reduction operation
+            Reduction operation to perform. Default: MPI.SUM
+
+        Returns
+        -------
+        np.ndarray
+            ndarray result of reduction
+
+        """
+        from mpi4py import MPI
+        return self.comm.allreduce(self.local_array, MPI.SUM if op is None else op)
+
+    def Allreduce(self, result_arr, op=None):
+        """Perform MPI reduction `op` within memory buffer.
+
+        Place results in `result_arr` for all ranks.
+
+        Parameters
+        ----------
+        op : MPI reduction operation
+            Reduction operation to perform. Default: MPI.SUM
+        """
+        from mpi4py import MPI
+        if self.shape != result_arr.shape:
+            raise ValueError(f"`result_arr` is shape {result_arr.shape}; expected {self.shape}")
+        self.comm.Allreduce(self, result_arr, MPI.SUM if op is None else op)
+
     def enumerate(self, axis):
         """Helper for enumerating over a given axis.
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1096,7 +1096,9 @@ class MPIArray(np.ndarray):
                     dist_axis = array.axis
                 else:
                     if dist_axis != array.axis:
-                        raise ValueError("The distributed axis for all MPIArrays in an expression should be the same")
+                        raise ValueError(
+                            "The distributed axis for all MPIArrays in an expression should be the same"
+                        )
 
                 args.append(array.local_array.view(np.ndarray))
             else:
@@ -1111,27 +1113,36 @@ class MPIArray(np.ndarray):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """Handles ufunc operations for MPIArray.
 
-        In NumPy, ufuncs are the various fundamental operations applied to ndarrays in an element-by-element fashion, such as add() and divide().
+        In NumPy, ufuncs are the various fundamental operations applied to
+        ndarrays in an element-by-element fashion, such as add() and divide().
         https://numpy.org/doc/stable/reference/ufuncs.html
 
-        ndarray has lots of built-in ufuncs. In order to use them, the MPIArrays need to be converted into ndarrays, otherwise NumPy reports a NotImplemented error.
+        ndarray has lots of built-in ufuncs. In order to use them, the MPIArrays
+        need to be converted into ndarrays, otherwise NumPy reports a
+        NotImplemented error.
 
-        The distributed axis for all input MPIArrays, is expected to be the same. Operations across the distributed axis, will not be permitted.
+        The distributed axis for all input MPIArrays, is expected to be the same.
+        Operations across the distributed axis, will not be permitted.
 
-        The new array will ehter be be distributed over that axis, or possibly one axis down for `reduce` methods, if they eliminate the distributed axis.
+        The new array will ehter be be distributed over that axis, or possibly
+        one axis down for `reduce` methods, if they eliminate the distributed axis.
 
-        For operations that normally return a scalar, the scalars will be wrapped into a 1D array, distributed across axis 0.
+        For operations that normally return a scalar, the scalars will be
+        wrapped into a 1D array, distributed across axis 0.
 
         Parameters
         ----------
         ufunc: <function>
             ufunc object that was called
         method: str
-            indicates which ufunc method was called. one of "__call__", "reduce", "reduceat", "accumulate", "outer", "inner"
+            indicates which ufunc method was called.
+            one of "__call__", "reduce", "reduceat", "accumulate", "outer", "inner"
         inputs: tuple
-            tuple of the input arguments to the ufunc. At least one of the inputs is an MPIArray.
+            tuple of the input arguments to the ufunc.
+            At least one of the inputs is an MPIArray.
         kwargs: dict
-            dictionary containing the optional input arguments of the ufunc. Important kwargs considered here are 'out' and 'axis'.
+            dictionary containing the optional input arguments of the ufunc.
+            Important kwargs considered here are 'out' and 'axis'.
         """
         # pylint: disable=no-member
         # known problem with super().__array_ufunc__
@@ -1204,7 +1215,8 @@ class MPIArray(np.ndarray):
         Parameters
         ----------
         obj : MPIArray or None
-            The original MPIArray being viewed or broadcast. When in the middle of a constructor, obj is set to None.
+            The original MPIArray being viewed or broadcast.
+            When in the middle of a constructor, obj is set to None.
         """
         # we are in the middle of a constructor, and the attributes
         # will be set when we return to it

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -708,7 +708,7 @@ class MPIArray(np.ndarray):
 
         # Check that the axis is valid and wrap to an actual position
         if axis < -naxis or axis >= naxis:
-            raise ValueError(
+            raise AxisException(
                 "Distributed axis %i not in range (%i, %i)" % (axis, -naxis, naxis - 1)
             )
         axis = naxis + axis if axis < 0 else axis
@@ -1159,7 +1159,7 @@ class MPIArray(np.ndarray):
                     dist_axis = array.axis
                 else:
                     if dist_axis != array.axis:
-                        raise ValueError(
+                        raise AxisException(
                             "The distributed axis for all MPIArrays in an expression should be the same"
                         )
 
@@ -1216,7 +1216,7 @@ class MPIArray(np.ndarray):
         args, dist_axis = MPIArray._mpi_to_ndarray(inputs)
 
         if "axis" in kwargs and (kwargs["axis"] == dist_axis):
-            raise ValueError(
+            raise AxisException(
                 f"operations along the distributed axis (in this case, {dist_axis}) are not allowed."
             )
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -220,11 +220,17 @@ class _global_resolver:
                 index for index, sl in enumerate(slobj) if not isinstance(sl, int)
             ].index(self.axis)
 
-            return MPIArray.wrap(
-                self.array.view(np.ndarray)[slobj],
-                axis=dist_axis,
-                comm=self.array._comm,
-            )
+            if dist_axis != self.axis:
+
+                return MPIArray.wrap(
+                    self.array.view(np.ndarray)[slobj],
+                    axis=dist_axis,
+                    comm=self.array._comm,
+                )
+            else:
+                return MPIArray.wrap(
+                    self.array[slobj], axis=dist_axis, comm=self.array._comm
+                )
 
     def __setitem__(self, slobj, value):
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1010,8 +1010,8 @@ class MPIArray(np.ndarray):
         tdata.local_shape = tuple(self.local_shape[ax] for ax in axes)
         tdata.local_offset = tuple(self.local_offset[ax] for ax in axes)
 
-        tdata._axis = list(axes).index(self.axis)
-        tdata._comm = self._comm
+        tdata.axis = list(axes).index(self.axis)
+        tdata.comm = self._comm
 
         return tdata
 
@@ -1053,11 +1053,11 @@ class MPIArray(np.ndarray):
 
         rdata = np.ndarray.reshape(self, local_shape)
 
-        rdata._axis = new_axis
-        rdata._comm = self._comm
-        rdata._local_shape = tuple(local_shape)
-        rdata._global_shape = tuple(global_shape)
-        rdata._local_offset = tuple(local_offset)
+        rdata.axis = new_axis
+        rdata.comm = self._comm
+        rdata.local_shape = tuple(local_shape)
+        rdata.global_shape = tuple(global_shape)
+        rdata.local_offset = tuple(local_offset)
 
         return rdata
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -16,7 +16,7 @@ Fourier transforming each of these two axes of the distributed array::
     nprod = 2
     ntime = 32
 
-    # Initalise array with (nfreq, nprod, ntime) global shape
+    Initialise array with (nfreq, nprod, ntime) global shape
     darr1 = MPIArray((nfreq, nprod, ntime), dtype=np.float64)
 
     # Load in data into parallel array
@@ -110,20 +110,33 @@ Direct Slicing Behaviour
 - Any indexing or slicing into the non-parallel axis, will also return a
   :class:`MPIArray`. The number associated with the parallel axis,
   will be adjusted if a slice results in an axis reduction.
-- Any indexing into the parallel axis will result into a local index on each rank,
-  returning a regular `numpy` array.
+- Any indexing into the parallel axis is discouraged. This behaviour is
+  deprecated. For now, it will result into a local index on each rank,
+  returning a regular `numpy` array, along with a warning.
+  In the future, it is encouraged to index into the local array
+  :py:attr:`MPIArray.local_array`, if you wish to locally index into
+  the parallel axis
 
 Direct Slicing Examples
 -----------------------
 
-    Direct indexing into parallel axis returns a numpy array
-    equal to local array indexing
+    Direct indexing into parallel axis is DEPRECATED.
+    For now, it will return a numpy array
+    equal to local array indexing, along with a warning.
+    This behaviour will be removed in the future.
 
     >>> darr = mpiarray.MPIArray((mpiutil.size,), axis=0)
     >>> (darr[0] == darr.local_array[0]).all()
     True
     >>> not hasattr(darr[0], "axis")
     True
+
+    If you wish to index into the parallel axis in a local array,
+    index into the local array.
+
+    >>> darr[:] = 1.0
+    >>> darr.local_array[0]
+    1.0
 
     indexing into non-parallel axes returns an MPIArray
     with appropriate attributes
@@ -180,7 +193,7 @@ ufunc Examples
     because the two arrays have different parallel axes
     >>> mpiarray.MPIArray((mpiutil.size, 4), axis=0) - mpiarray.MPIArray((mpiutil.size, 4), axis=1)
     Traceback (most recent call last):
-        ...
+    ...
     caput.mpiarray.AxisException: The distributed axis for all MPIArrays in an expression should be the same
 
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1105,6 +1105,10 @@ class MPIArray(np.ndarray):
 
         return (args, dist_axis)
 
+    # pylint: disable=inconsistent-return-statements
+    # array_ufunc is a special general function
+    # which facilitates the use of a diverse set of ufuncs
+    # some which return nothing, and some which return something
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """Handles ufunc operations for MPIArray.
 
@@ -1130,6 +1134,8 @@ class MPIArray(np.ndarray):
         kwargs: dict
             dictionary containing the optional input arguments of the ufunc. Important kwargs considered here are 'out' and 'axis'.
         """
+        # pylint: disable=no-member
+        # known problem with super().__array_ufunc__
 
         args = []
 
@@ -1151,13 +1157,13 @@ class MPIArray(np.ndarray):
         else:
             outputs = (None,) * ufunc.nout
 
-        results = super().__array_ufunc__(ufunc, method, *args, **kwargs) # pylint: disable=no-member
+        results = super().__array_ufunc__(ufunc, method, *args, **kwargs)
 
         if results is NotImplemented:
             return NotImplemented
 
         # operation is performed in-place, so we can just return
-        if method == 'at':
+        if method == "at":
             return
 
         if ufunc.nout == 1:
@@ -1182,11 +1188,11 @@ class MPIArray(np.ndarray):
                 ):  # case: the result is an array; convert back it into an MPIArray
                     ret.append(MPIArray.wrap(result, axis=dist_axis))
                 else:  # case: result is a scalar; convert to 1-d vector, distributed across axis 0
-                    ret.append(
-                        MPIArray.wrap(np.reshape(result, (1, 1)), axis=0)
-                    )
+                    ret.append(MPIArray.wrap(np.reshape(result, (1, 1)), axis=0))
 
         return ret[0] if len(ret) == 1 else tuple(ret)
+
+    # pylint: enable=inconsistent-return-statements
 
     def __array_finalize__(self, obj):
         """

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1095,9 +1095,8 @@ class MPIArray(np.ndarray):
                 if dist_axis is None:
                     dist_axis = array.axis
                 else:
-                    assert (
-                        dist_axis == array.axis
-                    ), "The distributed axis for all MPIArrays in an expression should be the same"
+                    if dist_axis != array.axis:
+                        raise ValueError("The distributed axis for all MPIArrays in an expression should be the same")
 
                 args.append(array.local_array.view(np.ndarray))
             else:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -278,6 +278,13 @@ class MPIArray(np.ndarray):
         else:
             return super().__getitem__(v)
 
+    def __repr__(self):
+        return self.local_array.__repr__()
+
+    def __str__(self):
+        return self.local_array.__str__()
+
+
     @property
     def global_shape(self):
         """

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -227,6 +227,17 @@ Reduction methods might result in a decrease in the distributed axis number
 >>> dist_arr = mpiarray.MPIArray((mpiutil.size, 4, 3), axis=1)
 >>> dist_arr.sum(axis=0).axis == 0
 True
+
+MPI.Comm
+=====
+
+mpi4py.MPI.Comm provides a wide variety of functions for communications across nodes
+https://mpi4py.readthedocs.io/en/stable/overview.html?highlight=allreduce#collective-communications
+
+They provide an upper-case and lower-case variant of many functions.
+With MPIArrays, please use the uppercase variant of the function. The lower-case variants involve
+an intermediate pickling process, which can lead to malformed arrays.
+
 """
 import os
 import time
@@ -1590,6 +1601,13 @@ def _mpi_to_ndarray(inputs):
 
     for array in inputs:
         if isinstance(array, MPIArray):
+            if not hasattr(array, 'axis'):
+                raise AxisException(
+                        "An input to a ufunc has an MPIArray, which is missing its axis property."
+                        "If using a lower-case MPI.Comm function, please use its upper-case alternative."
+                        "Pickling does not preserve the axis property."
+                        "Otherwise, please file an issue on caput with a stacktrace."
+                )
             if dist_axis is None:
                 dist_axis = array.axis
             else:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -845,9 +845,9 @@ class MPIArray(np.ndarray):
         return dist_arr
 
     def allreduce(self, op=None):
-        """Perform MPI reduction operation `op` by pickling local array.
+        """Perform MPI reduction `op` within memory buffer.
 
-        Return results for all ranks.
+        Return results to all ranks.
 
         Parameters
         ----------
@@ -856,31 +856,16 @@ class MPIArray(np.ndarray):
 
         Returns
         -------
-        np.ndarray
-            ndarray result of reduction
+        np.ndarray or scalar
+            ndarray result of reduction, unless it is vector (1,), then return scalar
+            mpi_array.sum().allreduce() should give the scalar sum of all entries.
 
         """
         from mpi4py import MPI
 
-        return self.comm.allreduce(self.local_array, MPI.SUM if op is None else op)
-
-    def Allreduce(self, result_arr, op=None):
-        """Perform MPI reduction `op` within memory buffer.
-
-        Place results in `result_arr` for all ranks.
-
-        Parameters
-        ----------
-        op : MPI reduction operation
-            Reduction operation to perform. Default: MPI.SUM
-        """
-        from mpi4py import MPI
-
-        if self.shape != result_arr.shape:
-            raise ValueError(
-                f"`result_arr` is shape {result_arr.shape}; expected {self.shape}"
-            )
+        result_arr = np.zeros_like(self)
         self.comm.Allreduce(self, result_arr, MPI.SUM if op is None else op)
+        return result_arr if result_arr.shape != (1,) else result_arr[0]
 
     def enumerate(self, axis):
         """Helper for enumerating over a given axis.

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1255,7 +1255,7 @@ class MPIArray(np.ndarray):
 
         # that ufunc was not implemented for ndarrays
         if results is NotImplemented:
-            raise NotImplementedError
+            return NotImplemented
 
         # operation was performed in-place, so we can just return
         if method == "at":

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -244,18 +244,22 @@ class MPIArray(np.ndarray):
 
         try:
             dist_axis_index = v[self.axis]
-            if (dist_axis_index == slice(None, None, None)) or (dist_axis_index == slice(0, self.local_shape[self.axis]-1, None)):
+            if dist_axis_index == slice(None, None, None) or dist_axis_index == slice(
+                0, self.local_array.shape[self.axis], None
+            ):
                 pass
             else:
-                raise AxisException(
-                        "Cannot sub-slice distributed axes"
-                )
+                raise AxisException("Cannot sub-slice distributed axes")
         except IndexError:
             pass
 
         # Figure out which is the distributed axis after the slicing, by
         # removing slice axes which are just ints from the mapping
-        dist_axis = [index for index, sl in enumerate(v) if not isinstance(sl, int) and not isinstance(sl, np.int64)]
+        dist_axis = [
+            index
+            for index, sl in enumerate(v)
+            if not isinstance(sl, int) and not isinstance(sl, np.int64)
+        ]
         try:
             dist_axis = dist_axis.index(self.axis)
         except ValueError:
@@ -288,12 +292,14 @@ class MPIArray(np.ndarray):
         else:
             return super().__getitem__(v)
 
+    def __setitem__(self, slobj, value):
+        self.local_array.__setitem__(slobj, value)
+
     def __repr__(self):
         return self.local_array.__repr__()
 
     def __str__(self):
         return self.local_array.__str__()
-
 
     @property
     def global_shape(self):

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1246,11 +1246,11 @@ class MPIArray(np.ndarray):
         slices = [slice(start, end) for start, end in zip(starts, ends)]
         return split_axis, slices
 
-
     # pylint: disable=inconsistent-return-statements
     # array_ufunc is a special general function
     # which facilitates the use of a diverse set of ufuncs
     # some which return nothing, and some which return something
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """Handles ufunc operations for MPIArray.
 
@@ -1486,6 +1486,7 @@ def _expand_sel(sel, naxis):
     if len(sel) < naxis:
         sel = list(sel) + [slice(None)] * (naxis - len(sel))
     return list(sel)
+
 
 def _mpi_to_ndarray(inputs):
     """Ensure a list with mixed MPIArrays and ndarrays are all ndarrays.

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1170,9 +1170,9 @@ class MPIArray(np.ndarray):
             results = (results,)
 
         if "reduce" in method:
-            # reduction methods eliminate axes, so the distributed axes might need to be recalculated
+            # reduction methods eliminate axes, so the distributed axes needs to be recalculated
             if results[0].shape and len(results[0].shape) < dist_axis + 1:
-                dist_axis -= 1
+                dist_axis = len(results[0].shape) - 1
 
         # Wrapping the results back into MPIArrays, distributed across the appropriate axis
         ret = []
@@ -1218,6 +1218,11 @@ class MPIArray(np.ndarray):
             axis = getattr(
                 obj, "axis", 0
             )  # probably not a good default! How would we find this out?
+
+            # if the array has been reduced, re-calibrate the distr axes
+            axis -= len(obj.shape) - len(self.shape)
+
+            axis = 0 if axis < 0 else axis
 
             # get length of distributed axis
             try:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -559,6 +559,8 @@ class MPIArray(np.ndarray):
         """
         return _global_resolver(self)
 
+
+    # pylint: disable=protected-access
     @classmethod
     def wrap(cls, array, axis, comm=None):
         """Turn a set of numpy arrays into a distributed MPIArray object.
@@ -626,6 +628,7 @@ class MPIArray(np.ndarray):
 
         return dist_arr
 
+    # pylint: enable=protected-access
     def redistribute(self, axis):
         """Change the axis that the array is distributed over.
 
@@ -1247,6 +1250,7 @@ class MPIArray(np.ndarray):
         return split_axis, slices
 
     # pylint: disable=inconsistent-return-statements
+    # pylint: disable=too-many-branches
     # array_ufunc is a special general function
     # which facilitates the use of a diverse set of ufuncs
     # some which return nothing, and some which return something
@@ -1351,6 +1355,7 @@ class MPIArray(np.ndarray):
         return ret[0] if len(ret) == 1 else tuple(ret)
 
     # pylint: enable=inconsistent-return-statements
+    # pylint: enable=too-many-branches
 
     def __array_finalize__(self, obj):
         """

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1226,9 +1226,11 @@ class MPIArray(np.ndarray):
         # we are in a ufunc, rebuild the attributes from the original MPIArray
         if isinstance(obj, MPIArray):
             comm = getattr(obj, "comm", mpiutil.world)
-            axis = getattr(
-                obj, "axis", 0
-            )  # probably not a good default! How would we find this out?
+            if hasattr(obj, "axis"):
+                axis = obj.axis
+            else:
+                raise Exception("Cannot construct output axis")
+
 
             # if the array has been reduced, re-calibrate the distr axes
             if len(self.shape) < axis + 1:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1229,30 +1229,27 @@ class MPIArray(np.ndarray):
         # we are in a ufunc, rebuild the attributes from the original MPIArray
         if isinstance(obj, MPIArray):
             comm = getattr(obj, "comm", mpiutil.world)
-            if hasattr(obj, "axis"):
-                axis = obj.axis
-            else:
-                raise Exception("Cannot construct output axis")
 
-            # if the array has been reduced, re-calibrate the distr axes
-            if len(self.shape) < axis + 1:
-                axis = len(self.shape) - 1
+        if hasattr(obj, "axis"):
+            axis = obj.axis
+        else:
+            raise Exception("Cannot construct output axis")
 
-            # Get shape and offset
-            lshape = self.shape
-            global_shape = list(lshape)
+        # Get shape and offset
+        lshape = self.shape
+        global_shape = list(lshape)
 
-            _, local_start, _ = mpiutil.split_local(global_shape[axis], comm=comm)
+        _, local_start, _ = mpiutil.split_local(global_shape[axis], comm=comm)
 
-            loffset = [0] * len(lshape)
-            loffset[axis] = local_start
+        loffset = [0] * len(lshape)
+        loffset[axis] = local_start
 
-            # Setup attributes
-            self._global_shape = tuple(global_shape)
-            self._axis = axis
-            self._local_shape = tuple(lshape)
-            self._local_offset = tuple(loffset)
-            self._comm = comm
+        # Setup attributes
+        self._global_shape = tuple(global_shape)
+        self._axis = axis
+        self._local_shape = tuple(lshape)
+        self._local_offset = tuple(loffset)
+        self._comm = comm
         return
 
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1375,7 +1375,7 @@ class MPIArray(np.ndarray):
                     ret.append(MPIArray.wrap(result, axis=dist_axis))
                 # case: result is a scalar; convert to 1-d vector, distributed across axis 0
                 else:
-                    ret.append(MPIArray.wrap(np.reshape(result, (1, 1)), axis=0))
+                    ret.append(MPIArray.wrap(np.reshape(result, (1,)), axis=0))
 
         return ret[0] if len(ret) == 1 else tuple(ret)
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -251,11 +251,12 @@ class MPIArray(np.ndarray):
 
         if dist_axis != self.axis:
 
-            return MPIArray.wrap(
-                self.view(np.ndarray).__getitem__(v),
-                axis=dist_axis,
-                comm=self._comm,
-            )
+            arr = self.view(np.ndarray).__getitem__(v)
+            global_shape = list(arr.shape)
+            global_shape[dist_axis] = self.global_shape[self.axis]
+            arr_mpi = MPIArray(tuple(global_shape), axis=dist_axis, comm=self._comm)
+            arr_mpi[:] = arr[:]
+            return arr_mpi
         else:
             return super().__getitem__(v)
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -449,6 +449,17 @@ class MPIArray(np.ndarray):
         """
         return self._axis
 
+    @axis.setter
+    def axis(self, var):
+        """
+        Set axis we are distributed over.
+
+        Parameters
+        ----------
+        var : int
+        """
+        self._axis = var
+
     @property
     def local_shape(self):
         """
@@ -518,6 +529,17 @@ class MPIArray(np.ndarray):
         """
         return self._comm
 
+    @comm.setter
+    def comm(self, var):
+        """
+        Set the communicator over which the array is distributed.
+
+        Parameters
+        ----------
+        var : MPI.Comm
+        """
+        self._comm = var
+
     def __new__(cls, global_shape, axis=0, comm=None, *args, **kwargs):
 
         # if mpiutil.world is None:
@@ -559,8 +581,6 @@ class MPIArray(np.ndarray):
         """
         return _global_resolver(self)
 
-
-    # pylint: disable=protected-access
     @classmethod
     def wrap(cls, array, axis, comm=None):
         """Turn a set of numpy arrays into a distributed MPIArray object.
@@ -620,15 +640,14 @@ class MPIArray(np.ndarray):
 
         # Setup attributes of class
         dist_arr = array.view(cls)
-        dist_arr._global_shape = tuple(global_shape)
-        dist_arr._axis = axis
-        dist_arr._local_shape = tuple(lshape)
-        dist_arr._local_offset = tuple(loffset)
-        dist_arr._comm = comm
+        dist_arr.global_shape = tuple(global_shape)
+        dist_arr.axis = axis
+        dist_arr.local_shape = tuple(lshape)
+        dist_arr.local_offset = tuple(loffset)
+        dist_arr.comm = comm
 
         return dist_arr
 
-    # pylint: enable=protected-access
     def redistribute(self, axis):
         """Change the axis that the array is distributed over.
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1188,16 +1188,15 @@ class MPIArray(np.ndarray):
         ret = []
 
         for result, output in zip(results, outputs):
-            if (
-                output is not None
-            ):  # case: results were placed in the array specified by `out`; return as is
+            # case: results were placed in the array specified by `out`; return as is
+            if output is not None:
                 ret.append(output)
             else:
-                if (
-                    result.shape
-                ):  # case: the result is an array; convert back it into an MPIArray
+                # case: the result is an array; convert back it into an MPIArray
+                if result.shape:
                     ret.append(MPIArray.wrap(result, axis=dist_axis))
-                else:  # case: result is a scalar; convert to 1-d vector, distributed across axis 0
+                # case: result is a scalar; convert to 1-d vector, distributed across axis 0
+                else:
                     ret.append(MPIArray.wrap(np.reshape(result, (1, 1)), axis=0))
 
         return ret[0] if len(ret) == 1 else tuple(ret)
@@ -1230,7 +1229,6 @@ class MPIArray(np.ndarray):
                 axis = obj.axis
             else:
                 raise Exception("Cannot construct output axis")
-
 
             # if the array has been reduced, re-calibrate the distr axes
             if len(self.shape) < axis + 1:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1179,10 +1179,14 @@ class MPIArray(np.ndarray):
         if ufunc.nout == 1:
             results = (results,)
 
-        if "reduce" in method:
-            # reduction methods eliminate axes, so the distributed axes needs to be recalculated
-            if results[0].shape and len(results[0].shape) < dist_axis + 1:
-                dist_axis = len(results[0].shape) - 1
+        if "reduce" in method and results[0].shape:
+            # reduction methods eliminate axes, so the distributed axes
+            # might need to be recalculated
+            # except when the user explicitly specifies keepdims
+            if not kwargs.get("keepdims", False):
+                reduction_axis = kwargs["axis"]
+                if reduction_axis < dist_axis:
+                    dist_axis -= 1
 
         # Wrapping the results back into MPIArrays, distributed across the appropriate axis
         ret = []

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -229,7 +229,7 @@ Reduction methods might result in a decrease in the distributed axis number
 True
 
 MPI.Comm
-=====
+========
 
 mpi4py.MPI.Comm provides a wide variety of functions for communications across nodes
 https://mpi4py.readthedocs.io/en/stable/overview.html?highlight=allreduce#collective-communications

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -449,7 +449,7 @@ class MPIArray(np.ndarray):
 
         # create an mpi array, with the appropriate parameters
         # fill it with the contents of the slice
-        arr_mpi = MPIArray(tuple(new_global_shape), axis=dist_axis, comm=self._comm)
+        arr_mpi = MPIArray(tuple(new_global_shape), axis=dist_axis, comm=self._comm, dtype=self.dtype)
         arr_mpi[:] = arr_sliced[:]
         return arr_mpi
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -248,16 +248,18 @@ class MPIArray(np.ndarray):
             v = v + (slice(None, None, None),) * (len(self.global_shape) - len(v))
 
         # __getitem__ should not be receiving sub-slices or direct indexes on the distributed axis
-        # global_slice should be used for indexing into distributed axis
+        # global_slice should be used for both
         dist_axis_index = v[self.axis]
-        if dist_axis_index != slice(None, None, None) and dist_axis_index != slice(
-            0, self.local_array.shape[self.axis], None
+        if (dist_axis_index != slice(None, None, None)) and (
+            dist_axis_index != slice(0, self.local_array.shape[self.axis], None)
         ):
             if isinstance(dist_axis_index, int):
                 raise AxisException(
                     "Cannot directly index distributed axis; use global_slice instead"
                 )
-            raise AxisException("Cannot sub-slice distributed axis")
+            raise AxisException(
+                "Cannot directly sub-slice distributed axis; use global_slice instead"
+            )
 
         # Figure out which is the axis number for the distributed axis after the slicing
         # by removing slice axes which are just ints from the mapping.

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1253,11 +1253,13 @@ class MPIArray(np.ndarray):
         global_shape = list(lshape)
 
         try:
-            axlen = global_shape[axis]
+            axlen = obj.global_shape[axis]
         except:
             raise AxisException(
                 f"Distributed axis {axis} does not exist in global shape {global_shape}"
             )
+
+        global_shape[axis] = axlen
 
         _, local_start, _ = mpiutil.split_local(axlen, comm=comm)
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -861,6 +861,7 @@ class MPIArray(np.ndarray):
 
         """
         from mpi4py import MPI
+
         return self.comm.allreduce(self.local_array, MPI.SUM if op is None else op)
 
     def Allreduce(self, result_arr, op=None):
@@ -874,8 +875,11 @@ class MPIArray(np.ndarray):
             Reduction operation to perform. Default: MPI.SUM
         """
         from mpi4py import MPI
+
         if self.shape != result_arr.shape:
-            raise ValueError(f"`result_arr` is shape {result_arr.shape}; expected {self.shape}")
+            raise ValueError(
+                f"`result_arr` is shape {result_arr.shape}; expected {self.shape}"
+            )
         self.comm.Allreduce(self, result_arr, MPI.SUM if op is None else op)
 
     def enumerate(self, axis):
@@ -1635,12 +1639,12 @@ def _mpi_to_ndarray(inputs):
 
     for array in inputs:
         if isinstance(array, MPIArray):
-            if not hasattr(array, 'axis'):
+            if not hasattr(array, "axis"):
                 raise AxisException(
-                        "An input to a ufunc has an MPIArray, which is missing its axis property."
-                        "If using a lower-case MPI.Comm function, please use its upper-case alternative."
-                        "Pickling does not preserve the axis property."
-                        "Otherwise, please file an issue on caput with a stacktrace."
+                    "An input to a ufunc has an MPIArray, which is missing its axis property."
+                    "If using a lower-case MPI.Comm function, please use its upper-case alternative."
+                    "Pickling does not preserve the axis property."
+                    "Otherwise, please file an issue on caput with a stacktrace."
                 )
             if dist_axis is None:
                 dist_axis = array.axis

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -847,7 +847,11 @@ class MPIArray(np.ndarray):
     def allreduce(self, op=None):
         """Perform MPI reduction `op` within memory buffer.
 
-        Return results to all ranks.
+        Usage is restricted to arrays with a single element per rank.
+        Returns same scalar final result to all ranks.
+
+        E.g. usage: mpi_array.sum().allreduce()
+        to every rank.
 
         Parameters
         ----------
@@ -856,16 +860,20 @@ class MPIArray(np.ndarray):
 
         Returns
         -------
-        np.ndarray or scalar
-            ndarray result of reduction, unless it is vector (1,), then return scalar
-            mpi_array.sum().allreduce() should give the scalar sum of all entries.
-
+        scalar
+            result of reduction
         """
         from mpi4py import MPI
 
+        if self.local_shape != (1,):
+            raise ValueError(
+                "MPIArray.allreduce()'s usage is restricted to arrays with a single element per rank.\n"
+                f"rank {self.comm.rank} has shape {self.local_shape}"
+            )
+
         result_arr = np.zeros_like(self)
         self.comm.Allreduce(self, result_arr, MPI.SUM if op is None else op)
-        return result_arr if result_arr.shape != (1,) else result_arr[0]
+        return result_arr[0]
 
     def enumerate(self, axis):
         """Helper for enumerating over a given axis.

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -215,7 +215,6 @@ class _global_resolver:
 
             return self.array[slobj]
 
-
     def __setitem__(self, slobj, value):
 
         slobj, _ = self._resolve_slice(slobj)
@@ -266,6 +265,9 @@ class MPIArray(np.ndarray):
             # grab the length of the distributed axes from the original
             # instead of performing an mpi.allreduce
             global_shape = list(arr.shape)
+            # if a single value
+            if not global_shape:
+                return arr
             global_shape[dist_axis] = self.global_shape[self.axis]
 
             # create an mpi array, with the appropriate parameters
@@ -275,7 +277,6 @@ class MPIArray(np.ndarray):
             return arr_mpi
         else:
             return super().__getitem__(v)
-
 
     @property
     def global_shape(self):

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -512,9 +512,9 @@ def test_reduce():
     sum_all = dist_array.sum()
     assert (sum_all == 4 * 3 * rank).all()
 
-    assert sum_all.local_shape == (1, 1)
+    assert sum_all.local_shape == (1,)
 
-    assert sum_all.global_shape == (size, 1)
+    assert sum_all.global_shape == (size,)
 
     # sum across a smaller numbered axes
     # this will result in an axes reduction
@@ -531,9 +531,9 @@ def test_reduce():
     sum_all = dist_array.sum()
     assert (sum_all == 4 * 3 * rank).all()
 
-    assert sum_all.local_shape == (1, 1)
+    assert sum_all.local_shape == (1,)
 
-    assert sum_all.global_shape == (size, 1)
+    assert sum_all.global_shape == (size,)
 
     dist_array = mpiarray.MPIArray((size, 4), axis=1)
     dist_array[:] = rank

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -338,6 +338,7 @@ class TestMPIArray(unittest.TestCase):
 
         # Check that directly slicing into distributed axis is blocked
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
+        darr[:] = rank
         with self.assertRaises(mpiarray.AxisException):
             darr[2, 0]
 
@@ -346,7 +347,7 @@ class TestMPIArray(unittest.TestCase):
         if rank != 0:
             assert dslice is None
         else:
-            assert dslice == 10.0
+            assert dslice == rank
 
         # Check ellipsis and slice at the end
         darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -425,14 +425,24 @@ class TestMPIArray(unittest.TestCase):
         # add differently shaped MPIArrays, with broadcasting
         dist_arr_2 = mpiarray.MPIArray((size, 1), axis=0)
         dist_arr_2[:] = rank - 1
-        assert (dist_arr + dist_arr_2 == 2 * rank -1).all()
+        assert (dist_arr + dist_arr_2 == 2 * rank - 1).all()
         assert (dist_arr + dist_arr_2).axis == 0
 
         # check that subtracting arrays with two different distributed axis fails
-        self.assertRaises(ValueError, np.subtract, mpiarray.MPIArray((size, 4), axis=0), mpiarray.MPIArray((size, 4), axis=1))
+        self.assertRaises(
+            ValueError,
+            np.subtract,
+            mpiarray.MPIArray((size, 4), axis=0),
+            mpiarray.MPIArray((size, 4), axis=1),
+        )
 
         # check that outer ufunc on arrays that cannot be broadcast fails
-        self.assertRaises(ValueError, np.multiply, mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0))
+        self.assertRaises(
+            ValueError,
+            np.multiply,
+            mpiarray.MPIArray((size, 3), axis=0),
+            mpiarray.MPIArray((size, 4), axis=0),
+        )
 
     def test_reduce(self):
         rank = mpiutil.rank
@@ -475,6 +485,7 @@ class TestMPIArray(unittest.TestCase):
         dist_array[:] = rank
 
         assert mpiarray.MPIArray((size, 4), axis=1).sum(axis=0).axis == 0
+
 
 #
 # class Testmpiarray(unittest.TestCase):

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -562,7 +562,19 @@ def test_reduce():
 
     assert sum_all.global_shape == (size,)
 
-    dist_array = mpiarray.MPIArray((size, 4), axis=1)
-    dist_array[:] = rank
-
     assert mpiarray.MPIArray((size, 4), axis=1).sum(axis=0).axis == 0
+
+    # test AllReduce
+    from mpi4py import MPI
+    dist_array = mpiarray.MPIArray((size, 4), axis=1)
+    dist_array[:] = 1
+
+    df_sum = np.sum(dist_array, axis=0)
+
+    assert (df_sum == 4).all()
+
+    df_total = np.zeros_like(df_sum)
+
+    dist_array.comm.Allreduce(df_sum, df_total, op=MPI.SUM)
+
+    assert (df_total == 4 * size).all()

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -343,11 +343,29 @@ class TestMPIArray(unittest.TestCase):
             darr[2, 0]
 
         # But, you can directly index with global_slice
-        dslice = darr.global_slice[2, 0]
-        if rank != 0:
-            assert dslice is None
-        else:
-            assert dslice == rank
+        if size >= 2:
+            dslice = darr.global_slice[2, 6]
+            if rank != 1:
+                assert dslice is None
+            else:
+                assert (dslice == rank).all()
+
+        # Check that printing the array does not trigger
+        # an exception
+        assert str(darr)
+
+        # the global slice should return a numpy array on rank=1, and None everywhere else
+        if size >= 2:
+            darr = mpiarray.MPIArray((20, 10, size * 5), axis=2)
+            darr[:] = rank
+            dslice = darr.global_slice[:, :, 6]
+            if rank != 1:
+                assert dslice is None
+            else:
+                nparr = np.ndarray((20, 10))
+                nparr[:] = rank
+                assert isinstance(dslice, np.ndarray)
+                assert (dslice == nparr).all()
 
         # Check ellipsis and slice at the end
         darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -344,6 +344,11 @@ class TestMPIArray(unittest.TestCase):
         with self.assertRaises(mpiarray.AxisException):
             darr[0]  # pylint: disable=pointless-statement
 
+        # Check that a single index works
+        darr = mpiarray.MPIArray((4, size), axis=1)
+        darr[:] = rank
+        assert(darr[0] == rank).all()
+
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         darr[:] = rank
         with self.assertRaises(mpiarray.AxisException):
@@ -468,7 +473,7 @@ class TestMPIArray(unittest.TestCase):
 
         # check that subtracting arrays with two different distributed axis fails
         self.assertRaises(
-            ValueError,
+            mpiarray.AxisException,
             np.subtract,
             mpiarray.MPIArray((size, 4), axis=0),
             mpiarray.MPIArray((size, 4), axis=1),

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -573,8 +573,6 @@ def test_reduce():
 
         df_sum = np.sum(dist_array, axis=0)
 
-        assert (df_sum == 4).all()
-
         df_total = np.zeros_like(df_sum)
 
         dist_array.comm.Allreduce(df_sum, df_total, op=MPI.SUM)
@@ -583,14 +581,11 @@ def test_reduce():
 
         assert (df_total == df_sum.allreduce()).all()
 
-        df_total = np.zeros_like(df_sum)
+        # Test MPIArray.allreduce(); ensure it returns
+        # an ndarray vector with appropriate values + shape
+        assert (dist_array.allreduce() == 4).all()
+        assert (dist_array.allreduce()).shape == (4, 1)
 
-        df_sum.Allreduce(df_total)
-
-        assert (df_total == 4 * size).all()
-
-        assert df_total.axis == 0
-
-        with pytest.raises(ValueError):
-            # ValueError should be raised, since df_total and dist_array are not the correct shape
-            dist_array.Allreduce(df_total)
+        # MPIArray.sum().allreduce() should give the scalar sum of
+        # all entries
+        assert df_sum.allreduce() == 4 * size

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -296,6 +296,9 @@ class TestMPIArray(unittest.TestCase):
         res = local_array[:, 3]
         assert (arr == res).all()
 
+        # Check that slices contain MPIArray attributes
+        assert hasattr(arr, "comm") and (arr.comm == darr.comm)
+
         # These tests denpend on the size being at least 2.
         if size > 1:
             # Check a slice on the parallel axis

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -334,13 +334,12 @@ class TestMPIArray(unittest.TestCase):
 
         assert dslice.global_shape == (10, size * 5)
         assert dslice.local_shape == (10, 5)
+        assert dslice.axis == 1
 
         # Check that directly slicing into distributed axis is blocked
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         with self.assertRaises(mpiarray.AxisException):
             darr[2, 0]
-        with self.assertRaises(mpiarray.AxisException):
-            darr.global_slice[2, 0:3]
 
         # But, you can directly index with global_slice
         dslice = darr.global_slice[2, 0]

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -335,6 +335,18 @@ class TestMPIArray(unittest.TestCase):
         assert dslice.global_shape == (10, size * 5)
         assert dslice.local_shape == (10, 5)
 
+        # Check that directly slicing into distributed axis is blocked
+        darr = mpiarray.MPIArray((20, size * 5), axis=1)
+        with self.assertRaises(mpiarray.AxisException):
+            darr[2, 0]
+
+        # But, you can directly index with global_slice
+        dslice = darr.global_slice[2, 0]
+        if rank != 0:
+            assert dslice is None
+        else:
+            assert dslice == 10.0
+
         # Check ellipsis and slice at the end
         darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)
         dslice = darr.global_slice[..., 4:9]
@@ -348,6 +360,8 @@ class TestMPIArray(unittest.TestCase):
 
         assert dslice.global_shape == (size, 136, 41)
         assert dslice.local_shape == (1, 136, 41)
+
+
 
     def test_global_setslice(self):
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -30,6 +30,7 @@ def test_construction():
 
     assert arr.local_shape == (10, l)
 
+
 def test_redistribution():
 
     gshape = (1, 11, 2, 14, 3, 4)
@@ -48,6 +49,7 @@ def test_redistribution():
 
     arr3 = arr.redistribute(axis=5)
     assert (arr3 == garr[:, :, :, :, :, s2:e2]).view(np.ndarray).all()
+
 
 def test_gather():
 
@@ -71,6 +73,7 @@ def test_gather():
         assert (ga == global_array).all()
     else:
         assert ga is None
+
 
 def test_wrap():
 
@@ -96,6 +99,7 @@ def test_wrap():
     if mpiutil.size > 1:
         with pytest.raises(Exception):
             mpiarray.MPIArray.wrap(df, axis=0)
+
 
 def test_io():
 
@@ -171,6 +175,7 @@ def test_io():
     if mpiutil.rank0 and os.path.exists(fname):
         os.remove(fname)
 
+
 def test_transpose():
 
     gshape = (1, 11, 2, 14)
@@ -232,6 +237,7 @@ def test_transpose():
     # Check axis
     assert arr4.axis == 2
 
+
 def test_reshape():
 
     gshape = (1, 11, 2, 14)
@@ -256,6 +262,7 @@ def test_reshape():
 
     # Check axis
     assert arr2.axis == 0
+
 
 # pylint: disable=too-many-statements
 def test_global_getslice():
@@ -397,6 +404,7 @@ def test_global_getslice():
     assert dslice.global_shape == (size, 136, 41)
     assert dslice.local_shape == (1, 136, 41)
 
+
 def test_global_setslice():
     rank = mpiutil.rank
     size = mpiutil.size
@@ -444,6 +452,7 @@ def test_global_setslice():
 
     assert (darr == local_array).all()
 
+
 def test_outer_ufunc():
     rank = mpiutil.rank
     size = mpiutil.size
@@ -482,6 +491,7 @@ def test_outer_ufunc():
     # check that outer ufunc on arrays that cannot be broadcast fails
     with pytest.raises(ValueError):
         np.multiply(mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0))
+
 
 def test_reduce():
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -285,7 +285,7 @@ def test_global_getslice():
 
     # Initialise the distributed array
     for li, _ in darr.enumerate(axis=0):
-        darr[li] = 10 * (10 * rank + li) + np.arange(20)
+        darr.local_array[li] = 10 * (10 * rank + li) + np.arange(20)
 
     # Construct numpy array which should be equivalent to the global array
     whole_array = (
@@ -358,9 +358,11 @@ def test_global_getslice():
     assert dslice.local_shape == (10, 5)
     assert dslice.axis == 1
 
-    # Check that directly indexing into distributed axis returns a numpy array equal to local array indexing
+    # Check that directly indexing into distributed axis returns a numpy array equal to
+    # local array indexing
     darr = mpiarray.MPIArray((size,), axis=0)
-    assert (darr[0] == darr.local_array[0]).all()
+    with pytest.warns(UserWarning):
+        assert (darr[0] == darr.local_array[0]).all()
 
     # Check that a single index into a non-parallel axis works
     darr = mpiarray.MPIArray((4, size), axis=1)
@@ -368,7 +370,8 @@ def test_global_getslice():
     assert (darr[0] == rank).all()
     assert darr[0].axis == 0
     # check that direct slicing into distributed axis returns a numpy array for local array slicing
-    assert (darr[2, 0] == darr.local_array[2, 0]).all()
+    with pytest.warns(UserWarning):
+        assert (darr[2, 0] == darr.local_array[2, 0]).all()
 
     darr = mpiarray.MPIArray((20, size * 5), axis=1)
     darr[:] = rank

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -431,8 +431,8 @@ class TestMPIArray(unittest.TestCase):
         # check that subtracting arrays with two different distributed axis fails
         self.assertRaises(ValueError, np.subtract, mpiarray.MPIArray((size, 4), axis=0), mpiarray.MPIArray((size, 4), axis=1))
 
-
-        # check that adding arrays that cannot be broadcast fails
+        # check that outer ufunc on arrays that cannot be broadcast fails
+        self.assertRaises(ValueError, np.multiply, mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0))
 
     def test_reduce(self):
         rank = mpiutil.rank

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -348,11 +348,10 @@ class TestMPIArray(unittest.TestCase):
         # Check that a single index into a non-parallel axis works
         darr = mpiarray.MPIArray((4, size), axis=1)
         darr[:] = rank
-        assert(darr[0] == rank).all()
-        assert(darr[0].axis == 0)
+        assert (darr[0] == rank).all()
+        assert darr[0].axis == 0
         # check that direct slicing into distributed axis returns a numpy array for local array slicing
         assert (darr[2, 0] == darr.local_array[2, 0]).all()
-
 
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         darr[:] = rank
@@ -383,7 +382,7 @@ class TestMPIArray(unittest.TestCase):
                 assert (dslice == nparr).all()
 
             # check that directly slicing a distributed axis returns a local array
-            assert(darr[:, :, 2:3] == darr.local_array[:, :, 2:3]).all()
+            assert (darr[:, :, 2:3] == darr.local_array[:, :, 2:3]).all()
 
         # Check ellipsis and slice at the end
         darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -6,569 +6,522 @@ Designed to be run as an MPI job with four processes like::
 """
 
 import os
-import unittest
+import pytest
 
 import numpy as np
 
 from caput import mpiutil, mpiarray
 
 
-class TestMPIArray(unittest.TestCase):
-    # pylint: disable=missing-function-docstring
-    # pylint: disable=no-member
-    def test_construction(self):
+# pylint: disable=missing-function-docstring
+# pylint: disable=no-member
+def test_construction():
 
-        arr = mpiarray.MPIArray((10, 11), axis=1)
+    arr = mpiarray.MPIArray((10, 11), axis=1)
 
-        l, s, _ = mpiutil.split_local(11)
+    l, s, _ = mpiutil.split_local(11)
 
-        # Check that global shape is set correctly
-        assert arr.global_shape == (10, 11)
+    # Check that global shape is set correctly
+    assert arr.global_shape == (10, 11)
 
-        assert arr.shape == (10, l)
+    assert arr.shape == (10, l)
 
-        assert arr.local_offset == (0, s)
+    assert arr.local_offset == (0, s)
 
-        assert arr.local_shape == (10, l)
+    assert arr.local_shape == (10, l)
 
-    def test_redistribution(self):
+def test_redistribution():
 
-        gshape = (1, 11, 2, 14, 3, 4)
-        nelem = np.prod(gshape)
-        garr = np.arange(nelem).reshape(gshape)
+    gshape = (1, 11, 2, 14, 3, 4)
+    nelem = np.prod(gshape)
+    garr = np.arange(nelem).reshape(gshape)
 
-        _, s0, e0 = mpiutil.split_local(11)
-        _, s1, e1 = mpiutil.split_local(14)
-        _, s2, e2 = mpiutil.split_local(4)
+    _, s0, e0 = mpiutil.split_local(11)
+    _, s1, e1 = mpiutil.split_local(14)
+    _, s2, e2 = mpiutil.split_local(4)
 
-        arr = mpiarray.MPIArray(gshape, axis=1, dtype=np.int64)
-        arr[:] = garr[:, s0:e0]
+    arr = mpiarray.MPIArray(gshape, axis=1, dtype=np.int64)
+    arr[:] = garr[:, s0:e0]
 
-        arr2 = arr.redistribute(axis=3)
-        assert (arr2 == garr[:, :, :, s1:e1]).view(np.ndarray).all()
+    arr2 = arr.redistribute(axis=3)
+    assert (arr2 == garr[:, :, :, s1:e1]).view(np.ndarray).all()
 
-        arr3 = arr.redistribute(axis=5)
-        assert (arr3 == garr[:, :, :, :, :, s2:e2]).view(np.ndarray).all()
+    arr3 = arr.redistribute(axis=5)
+    assert (arr3 == garr[:, :, :, :, :, s2:e2]).view(np.ndarray).all()
 
-    def test_gather(self):
+def test_gather():
 
-        rank = mpiutil.rank
-        size = mpiutil.size
-        block = 2
+    rank = mpiutil.rank
+    size = mpiutil.size
+    block = 2
 
-        global_shape = (2, 3, size * block)
-        global_array = np.zeros(global_shape, dtype=np.float64)
-        global_array[..., :] = np.arange(size * block)
+    global_shape = (2, 3, size * block)
+    global_array = np.zeros(global_shape, dtype=np.float64)
+    global_array[..., :] = np.arange(size * block)
 
-        arr = mpiarray.MPIArray(global_shape, dtype=np.float64, axis=2)
-        arr[:] = global_array[..., (rank * block) : ((rank + 1) * block)]
+    arr = mpiarray.MPIArray(global_shape, dtype=np.float64, axis=2)
+    arr[:] = global_array[..., (rank * block) : ((rank + 1) * block)]
 
-        assert (arr.allgather() == global_array).all()
+    assert (arr.allgather() == global_array).all()
 
-        gather_rank = 1 if size > 1 else 0
-        ga = arr.gather(rank=gather_rank)
+    gather_rank = 1 if size > 1 else 0
+    ga = arr.gather(rank=gather_rank)
 
-        if rank == gather_rank:
-            assert (ga == global_array).all()
+    if rank == gather_rank:
+        assert (ga == global_array).all()
+    else:
+        assert ga is None
+
+def test_wrap():
+
+    ds = mpiarray.MPIArray((10, 17))
+
+    df = np.fft.rfft(ds, axis=1)
+
+    assert isinstance(df, np.ndarray)
+
+    da = mpiarray.MPIArray.wrap(df, axis=0)
+
+    assert isinstance(da, mpiarray.MPIArray)
+    assert da.global_shape == (10, 9)
+    assert da.axis == 0
+
+    l0, _, _ = mpiutil.split_local(10)
+
+    assert da.local_shape == (l0, 9)
+
+    if mpiutil.rank0:
+        df = df[:-1]
+
+    if mpiutil.size > 1:
+        with pytest.raises(Exception):
+            mpiarray.MPIArray.wrap(df, axis=0)
+
+def test_io():
+
+    import h5py
+
+    # Cleanup directories
+    fname = "testdset.hdf5"
+
+    if mpiutil.rank0 and os.path.exists(fname):
+        os.remove(fname)
+
+    mpiutil.barrier()
+
+    gshape = (19, 17)
+
+    ds = mpiarray.MPIArray(gshape, dtype=np.int64)
+
+    ga = np.arange(np.prod(gshape)).reshape(gshape)
+
+    _, s0, e0 = mpiutil.split_local(gshape[0])
+    ds[:] = ga[s0:e0]
+
+    ds.redistribute(axis=1).to_hdf5(fname, "testds", create=True)
+
+    if mpiutil.rank0:
+
+        with h5py.File(fname, "r") as f:
+
+            h5ds = f["testds"][:]
+
+            assert (h5ds == ga).all()
+
+    ds2 = mpiarray.MPIArray.from_hdf5(fname, "testds")
+
+    assert (ds2 == ds).all()
+
+    mpiutil.barrier()
+
+    # Check that reading over another distributed axis works
+    ds3 = mpiarray.MPIArray.from_hdf5(fname, "testds", axis=1)
+    assert ds3.shape[0] == gshape[0]
+    assert ds3.shape[1] == mpiutil.split_local(gshape[1])[0]
+    ds3 = ds3.redistribute(axis=0)
+    assert (ds3 == ds).all()
+    mpiutil.barrier()
+
+    # Check a read with an arbitrary slice in there. This only checks the shape is correct.
+    ds4 = mpiarray.MPIArray.from_hdf5(
+        fname, "testds", axis=1, sel=(np.s_[3:10:2], np.s_[1:16:3])
+    )
+    assert ds4.shape[0] == 4
+    assert ds4.shape[1] == mpiutil.split_local(5)[0]
+    mpiutil.barrier()
+
+    # Check the read with a slice along the axis being read
+    ds5 = mpiarray.MPIArray.from_hdf5(
+        fname, "testds", axis=1, sel=(np.s_[:], np.s_[3:15:2])
+    )
+    assert ds5.shape[0] == gshape[0]
+    assert ds5.shape[1] == mpiutil.split_local(6)[0]
+    ds5 = ds5.redistribute(axis=0)
+    assert (ds5 == ds[:, 3:15:2]).all()
+    mpiutil.barrier()
+
+    # Check the read with a slice along the axis being read
+    ds6 = mpiarray.MPIArray.from_hdf5(
+        fname, "testds", axis=0, sel=(np.s_[:], np.s_[3:15:2])
+    )
+    ds6 = ds6.redistribute(axis=0)
+    assert (ds6 == ds[:, 3:15:2]).all()
+    mpiutil.barrier()
+
+    if mpiutil.rank0 and os.path.exists(fname):
+        os.remove(fname)
+
+def test_transpose():
+
+    gshape = (1, 11, 2, 14)
+
+    l0, s0, _ = mpiutil.split_local(11)
+
+    arr = mpiarray.MPIArray(gshape, axis=1, dtype=np.int64)
+
+    arr2 = arr.transpose(1, 3, 0, 2)
+
+    # Check type
+    assert isinstance(arr2, mpiarray.MPIArray)
+
+    # Check global shape
+    assert arr2.global_shape == (11, 14, 1, 2)
+
+    # Check local shape
+    assert arr2.local_shape == (l0, 14, 1, 2)
+
+    # Check local offset
+    assert arr2.local_offset == (s0, 0, 0, 0)
+
+    # Check axis
+    assert arr2.axis == 0
+
+    # Do the same test with a tuple as argument to transpose
+    arr3 = arr.transpose((1, 3, 0, 2))
+
+    # Check type
+    assert isinstance(arr3, mpiarray.MPIArray)
+
+    # Check global shape
+    assert arr3.global_shape == (11, 14, 1, 2)
+
+    # Check local shape
+    assert arr3.local_shape == (l0, 14, 1, 2)
+
+    # Check local offset
+    assert arr3.local_offset == (s0, 0, 0, 0)
+
+    # Check axis
+    assert arr3.axis == 0
+
+    # Do the same test with None as argument to transpose
+    arr4 = arr.transpose()
+
+    # Check type
+    assert isinstance(arr4, mpiarray.MPIArray)
+
+    # Check global shape
+    assert arr4.global_shape == (14, 2, 11, 1)
+
+    # Check local shape
+    assert arr4.local_shape == (14, 2, l0, 1)
+
+    # Check local offset
+    assert arr4.local_offset == (0, 0, s0, 0)
+
+    # Check axis
+    assert arr4.axis == 2
+
+def test_reshape():
+
+    gshape = (1, 11, 2, 14)
+
+    l0, s0, _ = mpiutil.split_local(11)
+
+    arr = mpiarray.MPIArray(gshape, axis=1, dtype=np.int64)
+
+    arr2 = arr.reshape((None, 28))
+
+    # Check type
+    assert isinstance(arr2, mpiarray.MPIArray)
+
+    # Check global shape
+    assert arr2.global_shape == (11, 28)
+
+    # Check local shape
+    assert arr2.local_shape == (l0, 28)
+
+    # Check local offset
+    assert arr2.local_offset == (s0, 0)
+
+    # Check axis
+    assert arr2.axis == 0
+
+# pylint: disable=too-many-statements
+def test_global_getslice():
+
+    rank = mpiutil.rank
+    size = mpiutil.size
+
+    darr = mpiarray.MPIArray((size * 5, 20), axis=0)
+
+    # Initialise the distributed array
+    for li, _ in darr.enumerate(axis=0):
+        darr[li] = 10 * (10 * rank + li) + np.arange(20)
+
+    # Construct numpy array which should be equivalent to the global array
+    whole_array = (
+        10
+        * (
+            10 * np.arange(4.0)[:, np.newaxis] + np.arange(5.0)[np.newaxis, :]
+        ).flatten()[:, np.newaxis]
+        + np.arange(20)[np.newaxis, :]
+    )
+
+    # Extract the section for each rank distributed along axis=0
+    local_array = whole_array[(rank * 5) : ((rank + 1) * 5)]
+
+    # Extract the correct section for each rank distributed along axis=0
+    local_array_T = whole_array[:, (rank * 5) : ((rank + 1) * 5)]
+
+    # Check that these are the same
+    assert (local_array == darr).all()
+
+    # Check a simple slice on the non-parallel axis
+    arr = darr.global_slice[:, 3:5]
+    res = local_array[:, 3:5]
+
+    assert isinstance(arr, mpiarray.MPIArray)
+    assert arr.axis == 0
+    assert (arr == res).all()
+
+    # Check a single element extracted from the non-parallel axis
+    arr = darr.global_slice[:, 3]
+    res = local_array[:, 3]
+    assert (arr == res).all()
+
+    # Check that slices contain MPIArray attributes
+    assert hasattr(arr, "comm") and (arr.comm == darr.comm)
+
+    # These tests depend on the size being at least 2.
+    if size > 1:
+        # Check a slice on the parallel axis
+        arr = darr.global_slice[:7, 3:5]
+
+        res = {0: local_array[:, 3:5], 1: local_array[:2, 3:5], 2: None, 3: None}
+
+        assert arr == res[rank] if arr is None else (arr == res[rank]).all()
+
+        # Check a single element from the parallel axis
+        arr = darr.global_slice[7, 3:5]
+
+        res = {0: None, 1: local_array[2, 3:5], 2: None, 3: None}
+
+        assert arr == res[rank] if arr is None else (arr == res[rank]).all()
+
+        # Check a slice on the redistributed parallel axis
+        darr_T = darr.redistribute(axis=1)
+        arr = darr_T.global_slice[3:5, :7]
+
+        res = {
+            0: local_array_T[3:5, :],
+            1: local_array_T[3:5, :2],
+            2: None,
+            3: None,
+        }
+
+        assert arr == res[rank] if arr is None else (arr == res[rank]).all()
+
+    # Check a slice that removes an axis
+    darr = mpiarray.MPIArray((10, 20, size * 5), axis=2)
+    dslice = darr.global_slice[:, 0, :]
+
+    assert dslice.global_shape == (10, size * 5)
+    assert dslice.local_shape == (10, 5)
+    assert dslice.axis == 1
+
+    # Check that directly indexing into distributed axis returns a numpy array equal to local array indexing
+    darr = mpiarray.MPIArray((size,), axis=0)
+    assert (darr[0] == darr.local_array[0]).all()
+
+    # Check that a single index into a non-parallel axis works
+    darr = mpiarray.MPIArray((4, size), axis=1)
+    darr[:] = rank
+    assert (darr[0] == rank).all()
+    assert darr[0].axis == 0
+    # check that direct slicing into distributed axis returns a numpy array for local array slicing
+    assert (darr[2, 0] == darr.local_array[2, 0]).all()
+
+    darr = mpiarray.MPIArray((20, size * 5), axis=1)
+    darr[:] = rank
+    # But, you can directly index with global_slice
+    if size > 1:
+        dslice = darr.global_slice[2, 6]
+        if rank != 1:
+            assert dslice is None
         else:
-            assert ga is None
-
-    def test_wrap(self):
-
-        ds = mpiarray.MPIArray((10, 17))
-
-        df = np.fft.rfft(ds, axis=1)
-
-        assert isinstance(df, np.ndarray)
-
-        da = mpiarray.MPIArray.wrap(df, axis=0)
-
-        assert isinstance(da, mpiarray.MPIArray)
-        assert da.global_shape == (10, 9)
-        assert da.axis == 0
-
-        l0, _, _ = mpiutil.split_local(10)
-
-        assert da.local_shape == (l0, 9)
-
-        if mpiutil.rank0:
-            df = df[:-1]
-
-        if mpiutil.size > 1:
-            with self.assertRaises(Exception):
-                mpiarray.MPIArray.wrap(df, axis=0)
-
-    def test_io(self):
-
-        import h5py
-
-        # Cleanup directories
-        fname = "testdset.hdf5"
-
-        if mpiutil.rank0 and os.path.exists(fname):
-            os.remove(fname)
-
-        mpiutil.barrier()
-
-        gshape = (19, 17)
-
-        ds = mpiarray.MPIArray(gshape, dtype=np.int64)
-
-        ga = np.arange(np.prod(gshape)).reshape(gshape)
-
-        _, s0, e0 = mpiutil.split_local(gshape[0])
-        ds[:] = ga[s0:e0]
-
-        ds.redistribute(axis=1).to_hdf5(fname, "testds", create=True)
-
-        if mpiutil.rank0:
-
-            with h5py.File(fname, "r") as f:
-
-                h5ds = f["testds"][:]
-
-                assert (h5ds == ga).all()
-
-        ds2 = mpiarray.MPIArray.from_hdf5(fname, "testds")
-
-        assert (ds2 == ds).all()
-
-        mpiutil.barrier()
-
-        # Check that reading over another distributed axis works
-        ds3 = mpiarray.MPIArray.from_hdf5(fname, "testds", axis=1)
-        assert ds3.shape[0] == gshape[0]
-        assert ds3.shape[1] == mpiutil.split_local(gshape[1])[0]
-        ds3 = ds3.redistribute(axis=0)
-        assert (ds3 == ds).all()
-        mpiutil.barrier()
-
-        # Check a read with an arbitrary slice in there. This only checks the shape is correct.
-        ds4 = mpiarray.MPIArray.from_hdf5(
-            fname, "testds", axis=1, sel=(np.s_[3:10:2], np.s_[1:16:3])
-        )
-        assert ds4.shape[0] == 4
-        assert ds4.shape[1] == mpiutil.split_local(5)[0]
-        mpiutil.barrier()
-
-        # Check the read with a slice along the axis being read
-        ds5 = mpiarray.MPIArray.from_hdf5(
-            fname, "testds", axis=1, sel=(np.s_[:], np.s_[3:15:2])
-        )
-        assert ds5.shape[0] == gshape[0]
-        assert ds5.shape[1] == mpiutil.split_local(6)[0]
-        ds5 = ds5.redistribute(axis=0)
-        assert (ds5 == ds[:, 3:15:2]).all()
-        mpiutil.barrier()
-
-        # Check the read with a slice along the axis being read
-        ds6 = mpiarray.MPIArray.from_hdf5(
-            fname, "testds", axis=0, sel=(np.s_[:], np.s_[3:15:2])
-        )
-        ds6 = ds6.redistribute(axis=0)
-        assert (ds6 == ds[:, 3:15:2]).all()
-        mpiutil.barrier()
-
-        if mpiutil.rank0 and os.path.exists(fname):
-            os.remove(fname)
-
-    def test_transpose(self):
-
-        gshape = (1, 11, 2, 14)
-
-        l0, s0, _ = mpiutil.split_local(11)
-
-        arr = mpiarray.MPIArray(gshape, axis=1, dtype=np.int64)
-
-        arr2 = arr.transpose(1, 3, 0, 2)
-
-        # Check type
-        assert isinstance(arr2, mpiarray.MPIArray)
-
-        # Check global shape
-        assert arr2.global_shape == (11, 14, 1, 2)
-
-        # Check local shape
-        assert arr2.local_shape == (l0, 14, 1, 2)
-
-        # Check local offset
-        assert arr2.local_offset == (s0, 0, 0, 0)
-
-        # Check axis
-        assert arr2.axis == 0
-
-        # Do the same test with a tuple as argument to transpose
-        arr3 = arr.transpose((1, 3, 0, 2))
-
-        # Check type
-        assert isinstance(arr3, mpiarray.MPIArray)
-
-        # Check global shape
-        assert arr3.global_shape == (11, 14, 1, 2)
-
-        # Check local shape
-        assert arr3.local_shape == (l0, 14, 1, 2)
-
-        # Check local offset
-        assert arr3.local_offset == (s0, 0, 0, 0)
-
-        # Check axis
-        assert arr3.axis == 0
-
-        # Do the same test with None as argument to transpose
-        arr4 = arr.transpose()
-
-        # Check type
-        assert isinstance(arr4, mpiarray.MPIArray)
-
-        # Check global shape
-        assert arr4.global_shape == (14, 2, 11, 1)
-
-        # Check local shape
-        assert arr4.local_shape == (14, 2, l0, 1)
-
-        # Check local offset
-        assert arr4.local_offset == (0, 0, s0, 0)
-
-        # Check axis
-        assert arr4.axis == 2
-
-    def test_reshape(self):
-
-        gshape = (1, 11, 2, 14)
-
-        l0, s0, _ = mpiutil.split_local(11)
-
-        arr = mpiarray.MPIArray(gshape, axis=1, dtype=np.int64)
-
-        arr2 = arr.reshape((None, 28))
-
-        # Check type
-        assert isinstance(arr2, mpiarray.MPIArray)
-
-        # Check global shape
-        assert arr2.global_shape == (11, 28)
-
-        # Check local shape
-        assert arr2.local_shape == (l0, 28)
-
-        # Check local offset
-        assert arr2.local_offset == (s0, 0)
-
-        # Check axis
-        assert arr2.axis == 0
-
-    # pylint: disable=too-many-statements
-    def test_global_getslice(self):
-
-        rank = mpiutil.rank
-        size = mpiutil.size
-
-        darr = mpiarray.MPIArray((size * 5, 20), axis=0)
-
-        # Initialise the distributed array
-        for li, _ in darr.enumerate(axis=0):
-            darr[li] = 10 * (10 * rank + li) + np.arange(20)
-
-        # Construct numpy array which should be equivalent to the global array
-        whole_array = (
-            10
-            * (
-                10 * np.arange(4.0)[:, np.newaxis] + np.arange(5.0)[np.newaxis, :]
-            ).flatten()[:, np.newaxis]
-            + np.arange(20)[np.newaxis, :]
-        )
-
-        # Extract the section for each rank distributed along axis=0
-        local_array = whole_array[(rank * 5) : ((rank + 1) * 5)]
-
-        # Extract the correct section for each rank distributed along axis=0
-        local_array_T = whole_array[:, (rank * 5) : ((rank + 1) * 5)]
-
-        # Check that these are the same
-        assert (local_array == darr).all()
-
-        # Check a simple slice on the non-parallel axis
-        arr = darr.global_slice[:, 3:5]
-        res = local_array[:, 3:5]
-
-        assert isinstance(arr, mpiarray.MPIArray)
-        assert arr.axis == 0
-        assert (arr == res).all()
-
-        # Check a single element extracted from the non-parallel axis
-        arr = darr.global_slice[:, 3]
-        res = local_array[:, 3]
-        assert (arr == res).all()
-
-        # Check that slices contain MPIArray attributes
-        assert hasattr(arr, "comm") and (arr.comm == darr.comm)
-
-        # These tests depend on the size being at least 2.
-        if size > 1:
-            # Check a slice on the parallel axis
-            arr = darr.global_slice[:7, 3:5]
-
-            res = {0: local_array[:, 3:5], 1: local_array[:2, 3:5], 2: None, 3: None}
-
-            assert arr == res[rank] if arr is None else (arr == res[rank]).all()
-
-            # Check a single element from the parallel axis
-            arr = darr.global_slice[7, 3:5]
-
-            res = {0: None, 1: local_array[2, 3:5], 2: None, 3: None}
-
-            assert arr == res[rank] if arr is None else (arr == res[rank]).all()
-
-            # Check a slice on the redistributed parallel axis
-            darr_T = darr.redistribute(axis=1)
-            arr = darr_T.global_slice[3:5, :7]
-
-            res = {
-                0: local_array_T[3:5, :],
-                1: local_array_T[3:5, :2],
-                2: None,
-                3: None,
-            }
-
-            assert arr == res[rank] if arr is None else (arr == res[rank]).all()
-
-        # Check a slice that removes an axis
-        darr = mpiarray.MPIArray((10, 20, size * 5), axis=2)
-        dslice = darr.global_slice[:, 0, :]
-
-        assert dslice.global_shape == (10, size * 5)
-        assert dslice.local_shape == (10, 5)
-        assert dslice.axis == 1
-
-        # Check that directly indexing into distributed axis returns a numpy array equal to local array indexing
-        darr = mpiarray.MPIArray((size,), axis=0)
-        assert (darr[0] == darr.local_array[0]).all()
-
-        # Check that a single index into a non-parallel axis works
-        darr = mpiarray.MPIArray((4, size), axis=1)
+            assert (dslice == rank).all()
+
+    # Check that printing the array does not trigger
+    # an exception
+    assert str(darr)
+
+    # more direct indexing into distributed with global_slice
+    # the global slice should return a numpy array on rank=1, and None everywhere else
+    if size >= 2:
+        darr = mpiarray.MPIArray((20, 10, size * 5), axis=2)
         darr[:] = rank
-        assert (darr[0] == rank).all()
-        assert darr[0].axis == 0
-        # check that direct slicing into distributed axis returns a numpy array for local array slicing
-        assert (darr[2, 0] == darr.local_array[2, 0]).all()
+        dslice = darr.global_slice[:, :, 6]
+        if rank != 1:
+            assert dslice is None
+        else:
+            nparr = np.ndarray((20, 10))
+            nparr[:] = rank
+            assert isinstance(dslice, np.ndarray)
+            assert (dslice == nparr).all()
 
-        darr = mpiarray.MPIArray((20, size * 5), axis=1)
-        darr[:] = rank
-        # But, you can directly index with global_slice
-        if size > 1:
-            dslice = darr.global_slice[2, 6]
-            if rank != 1:
-                assert dslice is None
-            else:
-                assert (dslice == rank).all()
+        # check that directly slicing a distributed axis returns a local array
+        assert (darr[:, :, 2:3] == darr.local_array[:, :, 2:3]).all()
 
-        # Check that printing the array does not trigger
-        # an exception
-        assert str(darr)
+    # Check ellipsis and slice at the end
+    darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)
+    dslice = darr.global_slice[..., 4:9]
 
-        # more direct indexing into distributed with global_slice
-        # the global slice should return a numpy array on rank=1, and None everywhere else
-        if size >= 2:
-            darr = mpiarray.MPIArray((20, 10, size * 5), axis=2)
-            darr[:] = rank
-            dslice = darr.global_slice[:, :, 6]
-            if rank != 1:
-                assert dslice is None
-            else:
-                nparr = np.ndarray((20, 10))
-                nparr[:] = rank
-                assert isinstance(dslice, np.ndarray)
-                assert (dslice == nparr).all()
+    assert dslice.global_shape == (size * 5, 20, 5)
+    assert dslice.local_shape == (5, 20, 5)
 
-            # check that directly slicing a distributed axis returns a local array
-            assert (darr[:, :, 2:3] == darr.local_array[:, :, 2:3]).all()
+    # Check slice that goes off the end of the axis
+    darr = mpiarray.MPIArray((size, 136, 2048), axis=0)
+    dslice = darr.global_slice[..., 2007:2087]
 
-        # Check ellipsis and slice at the end
-        darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)
-        dslice = darr.global_slice[..., 4:9]
+    assert dslice.global_shape == (size, 136, 41)
+    assert dslice.local_shape == (1, 136, 41)
 
-        assert dslice.global_shape == (size * 5, 20, 5)
-        assert dslice.local_shape == (5, 20, 5)
+def test_global_setslice():
+    rank = mpiutil.rank
+    size = mpiutil.size
 
-        # Check slice that goes off the end of the axis
-        darr = mpiarray.MPIArray((size, 136, 2048), axis=0)
-        dslice = darr.global_slice[..., 2007:2087]
+    darr = mpiarray.MPIArray((size * 5, 20), axis=0)
 
-        assert dslice.global_shape == (size, 136, 41)
-        assert dslice.local_shape == (1, 136, 41)
+    # Initialise the distributed array
+    for li, _ in darr.enumerate(axis=0):
+        darr[li] = 10 * (10 * rank + li) + np.arange(20)
 
-    def test_global_setslice(self):
-        rank = mpiutil.rank
-        size = mpiutil.size
+    # Construct numpy array which should be equivalent to the global array
+    whole_array = (
+        10
+        * (
+            10 * np.arange(4.0)[:, np.newaxis] + np.arange(5.0)[np.newaxis, :]
+        ).flatten()[:, np.newaxis]
+        + np.arange(20)[np.newaxis, :]
+    )
 
-        darr = mpiarray.MPIArray((size * 5, 20), axis=0)
+    # Extract the section for each rank distributed along axis=0
+    local_array = whole_array[(rank * 5) : ((rank + 1) * 5)]
+    # Set slice
 
-        # Initialise the distributed array
-        for li, _ in darr.enumerate(axis=0):
-            darr[li] = 10 * (10 * rank + li) + np.arange(20)
+    # Check a simple assignment to a slice along the non-parallel axis
+    darr.global_slice[:, 6] = -2.0
+    local_array[:, 6] = -2.0
 
-        # Construct numpy array which should be equivalent to the global array
-        whole_array = (
-            10
-            * (
-                10 * np.arange(4.0)[:, np.newaxis] + np.arange(5.0)[np.newaxis, :]
-            ).flatten()[:, np.newaxis]
-            + np.arange(20)[np.newaxis, :]
-        )
+    assert (darr == local_array).all()
 
-        # Extract the section for each rank distributed along axis=0
-        local_array = whole_array[(rank * 5) : ((rank + 1) * 5)]
-        # Set slice
+    # Check a partial assignment along the parallel axis
+    darr.global_slice[7:, 7:9] = -3.0
+    whole_array[7:, 7:9] = -3.0
 
-        # Check a simple assignment to a slice along the non-parallel axis
-        darr.global_slice[:, 6] = -2.0
-        local_array[:, 6] = -2.0
+    assert (darr == local_array).all()
 
-        assert (darr == local_array).all()
+    # Check assignment of a single index on the parallel axis
+    darr.global_slice[6] = np.arange(20.0)
+    whole_array[6] = np.arange(20.0)
 
-        # Check a partial assignment along the parallel axis
-        darr.global_slice[7:, 7:9] = -3.0
-        whole_array[7:, 7:9] = -3.0
+    assert (darr == local_array).all()
 
-        assert (darr == local_array).all()
+    # Check copy of one column into the other
+    darr.global_slice[:, 8] = darr.global_slice[:, 9]
+    whole_array[:, 8] = whole_array[:, 9]
 
-        # Check assignment of a single index on the parallel axis
-        darr.global_slice[6] = np.arange(20.0)
-        whole_array[6] = np.arange(20.0)
+    assert (darr == local_array).all()
 
-        assert (darr == local_array).all()
+def test_outer_ufunc():
+    rank = mpiutil.rank
+    size = mpiutil.size
 
-        # Check copy of one column into the other
-        darr.global_slice[:, 8] = darr.global_slice[:, 9]
-        whole_array[:, 8] = whole_array[:, 9]
+    dist_arr = mpiarray.MPIArray((size, 4), axis=0)
+    dist_arr[:] = rank
 
-        assert (darr == local_array).all()
+    dist_arr_add = dist_arr + dist_arr
 
-    def test_outer_ufunc(self):
-        rank = mpiutil.rank
-        size = mpiutil.size
+    dist_arr_add = dist_arr + dist_arr
+    dist_arr_mul = 2 * dist_arr
 
-        dist_arr = mpiarray.MPIArray((size, 4), axis=0)
-        dist_arr[:] = rank
+    # check that you can add two MPIArrays with the same shape
+    assert (dist_arr_add == 2 * rank).all()
 
-        dist_arr_add = dist_arr + dist_arr
+    # Check that you can multiply an MPIArray against a scalar
+    assert (dist_arr_mul == 2 * rank).all()
 
-        dist_arr_add = dist_arr + dist_arr
-        dist_arr_mul = 2 * dist_arr
+    # Check that basic output MPI attributes are correct
+    assert hasattr(dist_arr_add, "axis") and hasattr(dist_arr_add, "comm")
 
-        # check that you can add two MPIArrays with the same shape
-        assert (dist_arr_add == 2 * rank).all()
+    assert dist_arr_add.axis == 0
 
-        # Check that you can multiply an MPIArray against a scalar
-        assert (dist_arr_mul == 2 * rank).all()
+    assert dist_arr_add.comm is dist_arr.comm
 
-        # Check that basic output MPI attributes are correct
-        assert hasattr(dist_arr_add, "axis") and hasattr(dist_arr_add, "comm")
+    # add differently shaped MPIArrays, with broadcasting
+    dist_arr_2 = mpiarray.MPIArray((size, 1), axis=0)
+    dist_arr_2[:] = rank - 1
+    assert (dist_arr + dist_arr_2 == 2 * rank - 1).all()
+    assert (dist_arr + dist_arr_2).axis == 0
 
-        assert dist_arr_add.axis == 0
+    # check that subtracting arrays with two different distributed axis fails
+    with pytest.raises(mpiarray.AxisException):
+        mpiarray.MPIArray((size, 4), axis=0) - mpiarray.MPIArray((size, 4), axis=1)
 
-        assert dist_arr_add.comm is dist_arr.comm
+    # check that outer ufunc on arrays that cannot be broadcast fails
+    with pytest.raises(ValueError):
+        np.multiply(mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0))
 
-        # add differently shaped MPIArrays, with broadcasting
-        dist_arr_2 = mpiarray.MPIArray((size, 1), axis=0)
-        dist_arr_2[:] = rank - 1
-        assert (dist_arr + dist_arr_2 == 2 * rank - 1).all()
-        assert (dist_arr + dist_arr_2).axis == 0
+def test_reduce():
 
-        # check that subtracting arrays with two different distributed axis fails
-        self.assertRaises(
-            mpiarray.AxisException,
-            np.subtract,
-            mpiarray.MPIArray((size, 4), axis=0),
-            mpiarray.MPIArray((size, 4), axis=1),
-        )
+    rank = mpiutil.rank
+    size = mpiutil.size
 
-        # check that outer ufunc on arrays that cannot be broadcast fails
-        self.assertRaises(
-            ValueError,
-            np.multiply,
-            mpiarray.MPIArray((size, 3), axis=0),
-            mpiarray.MPIArray((size, 4), axis=0),
-        )
+    dist_array = mpiarray.MPIArray((size, 4, 3), axis=0)
+    dist_array[:] = rank
 
-    def test_reduce(self):
-        rank = mpiutil.rank
-        size = mpiutil.size
+    # sums across non-distributed axes should be permitted, and work as usual
+    assert (dist_array.sum(axis=1) == 4 * rank).all()
 
-        dist_array = mpiarray.MPIArray((size, 4, 3), axis=0)
-        dist_array[:] = rank
+    # sum() should reduce across all non-distributed axes
+    sum_all = dist_array.sum()
+    assert (sum_all == 4 * 3 * rank).all()
 
-        # sums across non-distributed axes should be permitted, and work as usual
-        assert (dist_array.sum(axis=1) == 4 * rank).all()
+    assert sum_all.local_shape == (1, 1)
 
-        # sum() should reduce across all non-distributed axes
-        sum_all = dist_array.sum()
-        assert (sum_all == 4 * 3 * rank).all()
+    assert sum_all.global_shape == (size, 1)
 
-        assert sum_all.local_shape == (1, 1)
+    # sum across a smaller numbered axes
+    # this will result in an axes reduction
+    dist_array = mpiarray.MPIArray((size, 4, 3), axis=1)
+    dist_array[:] = rank
 
-        assert sum_all.global_shape == (size, 1)
+    assert (dist_array.sum(axis=0) == 4 * rank).all()
 
-        # sum across a smaller numbered axes
-        # this will result in an axes reduction
-        dist_array = mpiarray.MPIArray((size, 4, 3), axis=1)
-        dist_array[:] = rank
+    # check that the new axes was calculated accordingly
+    assert (dist_array.sum(axis=0)).axis == 0
 
-        assert (dist_array.sum(axis=0) == 4 * rank).all()
+    assert dist_array.sum(axis=0, keepdims=True).axis == 1
 
-        # check that the new axes was calculated accordingly
-        assert (dist_array.sum(axis=0)).axis == 0
+    sum_all = dist_array.sum()
+    assert (sum_all == 4 * 3 * rank).all()
 
-        assert dist_array.sum(axis=0, keepdims=True).axis == 1
+    assert sum_all.local_shape == (1, 1)
 
-        sum_all = dist_array.sum()
-        assert (sum_all == 4 * 3 * rank).all()
+    assert sum_all.global_shape == (size, 1)
 
-        assert sum_all.local_shape == (1, 1)
+    dist_array = mpiarray.MPIArray((size, 4), axis=1)
+    dist_array[:] = rank
 
-        assert sum_all.global_shape == (size, 1)
-
-        dist_array = mpiarray.MPIArray((size, 4), axis=1)
-        dist_array[:] = rank
-
-        assert mpiarray.MPIArray((size, 4), axis=1).sum(axis=0).axis == 0
-
-
-#
-# class Testmpiarray(unittest.TestCase):
-#
-#     def test_dataset(self):
-#
-#         fname = 'testdset.hdf5'
-#
-#         if mpiutil.rank0:
-#             if os.path.exists(fname):
-#                 os.remove(fname)
-#
-#         mpiutil.barrier()
-#
-#         class TestDataset(mpiarray.mpiarray):
-#             _common = {'a': None}
-#             _distributed = {'b': None}
-#
-#         td1 = TestDataset()
-#         td1.common['a'] = np.arange(12)
-#         td1.attrs['message'] = 'meh'
-#
-#         gshape = (19, 17)
-#         ds = mpiarray.MPIArray(gshape, dtype=np.float64)
-#         ds[:] = np.random.standard_normal(ds.local_shape)
-#
-#         td1.distributed['b'] = ds
-#         td1.to_hdf5(fname)
-#
-#         td2 = TestDataset.from_hdf5(fname)
-#
-#         assert (td1['a'] == td2['a']).all()
-#         assert (td1['b'] == td2['b']).all()
-#         assert (td1.attrs['message'] == td2.attrs['message'])
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert mpiarray.MPIArray((size, 4), axis=1).sum(axis=0).axis == 0

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -453,12 +453,14 @@ class TestMPIArray(unittest.TestCase):
         assert sum_all.global_shape == (size, 1)
 
         # sum across a smaller numbered axes
+        # this will result in an axes reduction
         dist_array = mpiarray.MPIArray((size, 4, 3), axis=1)
         dist_array[:] = rank
 
         assert (dist_array.sum(axis=0) == 4 * rank).all()
 
-        assert (dist_array.sum(axis=0)).axis == 1
+        # check that the new axes was calculated accordingly
+        assert (dist_array.sum(axis=0)).axis == 0
 
         assert dist_array.sum(axis=0, keepdims=True).axis == 1
 
@@ -472,7 +474,8 @@ class TestMPIArray(unittest.TestCase):
         dist_array = mpiarray.MPIArray((size, 4), axis=1)
         dist_array[:] = rank
 
-        assert (dist_array.sum(axis=0)).axis == 0
+        assert mpiarray.MPIArray((size, 4), axis=1).sum(axis=0).axis == 0
+
 #
 # class Testmpiarray(unittest.TestCase):
 #

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -567,6 +567,7 @@ def test_reduce():
     # test AllReduce
     if size > 1:
         from mpi4py import MPI
+
         dist_array = mpiarray.MPIArray((size, 4), axis=1)
         dist_array[:] = 1
 
@@ -581,7 +582,6 @@ def test_reduce():
         assert (df_total == 4 * size).all()
 
         assert (df_total == df_sum.allreduce()).all()
-
 
         df_total = np.zeros_like(df_sum)
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -348,6 +348,7 @@ class TestMPIArray(unittest.TestCase):
         darr = mpiarray.MPIArray((4, size), axis=1)
         darr[:] = rank
         assert(darr[0] == rank).all()
+        assert(darr[0].axis == 0)
 
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         darr[:] = rank

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -452,6 +452,25 @@ def test_global_setslice():
 
     assert (darr == local_array).all()
 
+    # test setting complex dtypes
+
+    darr_complex = mpiarray.MPIArray((size * 5, 20), axis=0, dtype=np.complex64)
+
+    darr_complex[:] = 4
+    assert darr_complex.dtype == np.complex64
+    assert (darr_complex == 4. + 0.j).all()
+
+    darr_complex[:] = 2.0 + 1.345j
+
+    assert darr_complex.dtype == np.complex64
+    assert (darr_complex == 2.0 + 1.345j).all()
+
+    darr_float = mpiarray.MPIArray((size * 5, 20), axis=0, dtype=np.float64)
+
+    darr_float[:] = 4.0
+    assert darr_float.dtype == np.float64
+    assert (darr_float == 4.0).all()
+
 
 def test_outer_ufunc():
     rank = mpiutil.rank
@@ -495,6 +514,14 @@ def test_outer_ufunc():
             mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0)
         )
     # pylint: enable=expression-not-assigned
+
+    # test ufuncs with complex dtypes
+
+    dist_complex = mpiarray.MPIArray((size, 4), axis=0, dtype=np.complex64)
+    dist_complex_add = dist_complex + dist_complex
+
+    assert (dist_complex_add == dist_complex + dist_complex).all()
+    assert dist_complex_add.dtype == np.complex64
 
 
 def test_reduce():

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -439,8 +439,27 @@ class TestMPIArray(unittest.TestCase):
 
         assert sum_all.global_shape == (size, 1)
 
+        # sum across a smaller numbered axes
+        dist_array = mpiarray.MPIArray((size, 4, 3), axis=1)
+        dist_array[:] = rank
 
+        assert (dist_array.sum(axis=0) == 4 * rank).all()
 
+        assert (dist_array.sum(axis=0)).axis == 1
+
+        assert(dist_array.sum(axis=0, keepdims=True).axis == 1)
+
+        sum_all = dist_array.sum()
+        assert (sum_all == 4 * 3 * rank).all()
+
+        assert sum_all.local_shape == (1, 1)
+
+        assert sum_all.global_shape == (size, 1)
+
+        dist_array = mpiarray.MPIArray((size, 4), axis=1)
+        dist_array[:] = rank
+
+        assert (dist_array.sum(axis=0)).axis == 0
 #
 # class Testmpiarray(unittest.TestCase):
 #

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -339,6 +339,8 @@ class TestMPIArray(unittest.TestCase):
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         with self.assertRaises(mpiarray.AxisException):
             darr[2, 0]
+        with self.assertRaises(mpiarray.AxisException):
+            darr.global_slice[2, 0:3]
 
         # But, you can directly index with global_slice
         dslice = darr.global_slice[2, 0]

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -340,6 +340,10 @@ class TestMPIArray(unittest.TestCase):
         assert dslice.axis == 1
 
         # Check that directly slicing into distributed axis is blocked
+        darr = mpiarray.MPIArray((size,), axis=0)
+        with self.assertRaises(mpiarray.AxisException):
+            darr[0]  # pylint: disable=pointless-statement
+
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         darr[:] = rank
         with self.assertRaises(mpiarray.AxisException):

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -341,19 +341,17 @@ class TestMPIArray(unittest.TestCase):
         assert dslice.local_shape == (10, 5)
         assert dslice.axis == 1
 
-        # Check that directly indexing into distributed axis is blocked
+        # Check that directly indexing into distributed axis returns a numpy array equal to local array indexing
         darr = mpiarray.MPIArray((size,), axis=0)
-        with self.assertRaises(mpiarray.AxisException):
-            darr[0]  # pylint: disable=pointless-statement
+        assert (darr[0] == darr.local_array[0]).all()
 
         # Check that a single index into a non-parallel axis works
         darr = mpiarray.MPIArray((4, size), axis=1)
         darr[:] = rank
         assert(darr[0] == rank).all()
         assert(darr[0].axis == 0)
-        # again that direct indexing into distributed axis is blocked
-        with self.assertRaises(mpiarray.AxisException):
-            darr[2, 0]  # pylint: disable=pointless-statement
+        # check that direct slicing into distributed axis returns a numpy array for local array slicing
+        assert (darr[2, 0] == darr.local_array[2, 0]).all()
 
 
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
@@ -384,9 +382,8 @@ class TestMPIArray(unittest.TestCase):
                 assert isinstance(dslice, np.ndarray)
                 assert (dslice == nparr).all()
 
-            # check that directly slicing a distributed axis is blocked
-            with self.assertRaises(mpiarray.AxisException):
-                darr[:, :, 2:3]
+            # check that directly slicing a distributed axis returns a local array
+            assert(darr[:, :, 2:3] == darr.local_array[:, :, 2:3]).all()
 
         # Check ellipsis and slice at the end
         darr = mpiarray.MPIArray((size * 5, 20, 10), axis=0)

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -14,6 +14,8 @@ from caput import mpiutil, mpiarray
 
 
 class TestMPIArray(unittest.TestCase):
+    # pylint: disable=missing-function-docstring
+    # pylint: disable=no-member
     def test_construction(self):
 
         arr = mpiarray.MPIArray((10, 11), axis=1)
@@ -255,6 +257,7 @@ class TestMPIArray(unittest.TestCase):
         # Check axis
         assert arr2.axis == 0
 
+    # pylint: disable=too-many-statements
     def test_global_getslice(self):
 
         rank = mpiutil.rank
@@ -340,7 +343,7 @@ class TestMPIArray(unittest.TestCase):
         darr = mpiarray.MPIArray((20, size * 5), axis=1)
         darr[:] = rank
         with self.assertRaises(mpiarray.AxisException):
-            darr[2, 0]
+            darr[2, 0]  # pylint: disable=pointless-statement
 
         # But, you can directly index with global_slice
         if size >= 2:
@@ -381,10 +384,7 @@ class TestMPIArray(unittest.TestCase):
         assert dslice.global_shape == (size, 136, 41)
         assert dslice.local_shape == (1, 136, 41)
 
-
-
     def test_global_setslice(self):
-
         rank = mpiutil.rank
         size = mpiutil.size
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -485,12 +485,16 @@ def test_outer_ufunc():
     assert (dist_arr + dist_arr_2).axis == 0
 
     # check that subtracting arrays with two different distributed axis fails
+    # pylint: disable=expression-not-assigned
     with pytest.raises(mpiarray.AxisException):
         mpiarray.MPIArray((size, 4), axis=0) - mpiarray.MPIArray((size, 4), axis=1)
 
     # check that outer ufunc on arrays that cannot be broadcast fails
     with pytest.raises(ValueError):
-        np.multiply(mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0))
+        np.multiply(
+            mpiarray.MPIArray((size, 3), axis=0), mpiarray.MPIArray((size, 4), axis=0)
+        )
+    # pylint: enable=expression-not-assigned
 
 
 def test_reduce():


### PR DESCRIPTION
If used with draco, requires: https://github.com/radiocosmology/draco/pull/125

# Subclassing NumPy arrays 101
`view(MPIArray)` -> `__array_finalize__`
`MPIArray[slice]` -> `__getitem__` -> `__array_finalize__`
`MPIArray()` -> `__new__` -> `__array_finalize__`

ufuncs are the universal functions that are applied element by element in nparrays. Such a `np.add()`, `np.multiply()`. If they end up summing over an axis, they are a ufunc with a `reduce` method. If they go element-by-element, they are a ufunc with an `outer` method. If they occur in-place, they have an `at` method.

ufunc -> `__array_ufunc__`

More links on the role all these various functions play in writing subclasses for NumPy arrays can be found here: https://github.com/chime-experiment/Pipeline/issues/81

## New Exceptions

The new `AxisException` will be added. It will be raised when there are issues involving the integrity of the distributed axis with MPIArrays.

## __getitem__
- When you use `global_slice` to index into a distributed axis, then it will return an array for the rank on which the index exists, and `None` otherwise.
- When you slice on a non-distributed axis, `__getitem__` will return an MPIArray, whose distributed axes number might be lower than the original array, depending on if the slice results in an axis reduction. It is assumed that the distributed axis length is unchanged. An `mpiutil.split_local` call will be made.
- When you directly slice into a distributed axis, it will index into the local arrays on each rank, and return a regular numpy array. This behaviour will be deprecated, and replaced with the raising of an `AxisException`.

## ufunc

- Upon a ufunc being executed, both inputs and outputs are converted to
standard nparrays, and then the nparray ufunc is called
- all inputted MPIArrays *must* be distributed along the same axes. An `AxisException` will be called, if they are not.
- if no output are provided, the results are converted back to MPIArrays. The new array will either be distributed over that axis, or possibly one axis down for `reduce` methods. `keepdims` kwargs are handled.
- If you pass a kwarg `axis` to the ufunc, it must not be the distributed axis. Operations along the distributed axis are not allowed.
- For operations that normally return a scalar, the scalars will be wrapped into a 1D array, distributed across axis 0.
- To produce the MPIArray output, `MPIArray.wrap(..)` is called. This means there is a call to `mpiutil.split_local` and `mpiutil.allreduce`.

## __array_finalize__

This is called whenever a user uses `.view()`, `__new__`, and broadcasts on an MPIArray. It finalizes the creation of the output MPIArray. `view()`s can occur with `__getitem__` calls.

If it is a `__new__` call, it does nothing.

If we are in an `np.ndarray.view()` call, it does nothing. This should only occur when we are within a `wrap()`

If we are in a `view()`, it grabs the attributes from the origin array. 


## Misc

If a user wishes to create an MPIArray from an ndarray, they should use `MPIArray.wrap()`. They should not use `ndarray.view(MPIArray)`.


https://github.com/chime-experiment/Pipeline/issues/81