### PR TITLE
fix(OneAndAone): move validation to special function

### DIFF
--- a/caput/mpiutil.py
+++ b/caput/mpiutil.py
@@ -313,7 +313,7 @@ def split_m(n, m):
     base = n // m
     rem = n % m
 
-    part = base * np.ones(m, dtype=np.int) + (np.arange(m) < rem).astype(np.int)
+    part = base * np.ones(m, dtype=int) + (np.arange(m) < rem).astype(int)
 
     bound = np.cumsum(np.insert(part, 0, 0))
 

--- a/caput/tests/conftest.py
+++ b/caput/tests/conftest.py
@@ -1,7 +1,10 @@
-"""Pytest fixtures that can be used by all unit tests."""
+"""Pytest fixtures and simple tasks that can be used by all unit tests."""
 
 import numpy as np
 import pytest
+
+from caput.pipeline import PipelineStopIteration, TaskBase, IterBase
+from caput import config
 
 
 @pytest.fixture(scope="session")
@@ -16,3 +19,72 @@ def datasets():
     dset2 = dset2.reshape((len_axis, len_axis))
 
     return dset1, dset2
+
+
+class PrintEggs(TaskBase):
+    """Simple task used for testing."""
+
+    eggs = config.Property(proptype=list)
+
+    def __init__(self, *args, **kwargs):
+        self.i = 0
+        super().__init__(*args, **kwargs)
+
+    def setup(self, requires=None):
+        print("Setting up PrintEggs.")
+
+    def next(self, _input=None):
+        if self.i >= len(self.eggs):
+            raise PipelineStopIteration()
+        print("Spam and %s eggs." % self.eggs[self.i])
+        self.i += 1
+
+    def finish(self):
+        print("Finished PrintEggs.")
+
+
+class GetEggs(TaskBase):
+    """Simple task used for testing."""
+
+    eggs = config.Property(proptype=list)
+
+    def __init__(self, *args, **kwargs):
+        self.i = 0
+        super().__init__(*args, **kwargs)
+
+    def setup(self, requires=None):
+        print("Setting up GetEggs.")
+
+    def next(self, _input=None):
+        if self.i >= len(self.eggs):
+            raise PipelineStopIteration()
+        egg = self.eggs[self.i]
+        self.i += 1
+        return egg
+
+    def finish(self):
+        print("Finished GetEggs.")
+
+
+class CookEggs(IterBase):
+    """Simple task used for testing."""
+
+    style = config.Property(proptype=str)
+
+    def setup(self, requires=None):
+        print("Setting up CookEggs.")
+
+    def process(self, _input):
+        print("Cooking %s %s eggs." % (self.style, input))
+
+    def finish(self):
+        print("Finished CookEggs.")
+
+    def read_input(self, filename):
+        raise NotImplementedError()
+
+    def read_output(self, filename):
+        raise NotImplementedError()
+
+    def write_output(self, filename, output):
+        raise NotImplementedError()

--- a/caput/tests/test_pipeline.py
+++ b/caput/tests/test_pipeline.py
@@ -1,0 +1,39 @@
+"""Test running the caput.pipeline."""
+import tempfile
+
+from caput.scripts.runner import cli
+
+eggs_conf = """
+---
+pipeline:
+  tasks:
+    - type: caput.tests.conftest.PrintEggs
+      params: eggs_params
+
+    - type: caput.tests.conftest.GetEggs
+      params: eggs_params
+      out: egg
+
+    - type: caput.tests.conftest.CookEggs
+      params: cook_params
+      in: egg
+
+eggs_params:
+  eggs: ['green', 'duck', 'ostrich']
+
+cook_params:
+  style: 'fried'
+"""
+
+
+def test_pipeline():
+    """Test running a very simple pipeline."""
+    with tempfile.NamedTemporaryFile("w+") as configfile:
+        configfile.write(eggs_conf)
+        configfile.flush()
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run", configfile.name])
+        print(result.output)
+        assert result.exit_code == 0

--- a/caput/tests/test_time.py
+++ b/caput/tests/test_time.py
@@ -440,7 +440,7 @@ def test_rise_set_times(chime, eph):
         [1604535925.5065, 1604588383.0504, 1604622231.5790, 1604674881.4216],
         dtype=np.float64,
     )
-    precalc_risings = np.array([False, True, False, True], dtype=np.bool)
+    precalc_risings = np.array([False, True, False, True], dtype=bool)
 
     times, risings = chime.rise_set_times(eph["sun"], dts, dte)
 

--- a/caput/time.py
+++ b/caput/time.py
@@ -828,7 +828,7 @@ def datetime_to_unix(dt):
     return since_epoch.total_seconds()
 
 
-@vectorize(otypes=[np.unicode])
+@vectorize(otypes=[str])
 def datetime_to_timestr(dt):
     """Converts a :class:`~datetime.datetime` to "YYYYMMDDTHHMMSSZ" format.
 
@@ -902,7 +902,7 @@ def leap_seconds_between(time_a, time_b):
     # Calculate the shift in timescales which should only happen when leap
     # seconds are added/removed
     time_shift = delta_tt - delta_unix
-    time_shift_int = np.around(time_shift).astype(np.int)
+    time_shift_int = np.around(time_shift).astype(int)
 
     # Check that the shift is an integer number of seconds. I don't know why
     # this wouldn't be true, but if it's not it means things have gone crazy


### PR DESCRIPTION
~Set up in, out and requires keys in constructor instead of in Manager.add_task.~
Do validation of special keys in `validate()`, instead of in constructor

Closes #148