### PR TITLE
Allow variable substitution into pipeline scripts

### DIFF
--- a/caput/config.py
+++ b/caput/config.py
@@ -93,7 +93,8 @@ class Property:
         # Ensure the property name has been found and set
         self._set_propname(obj)
 
-        # If the value has not been set, return the default, otherwise return the actual value.
+        # If the value has not been set, return the default, otherwise return the
+        # actual value.
         if self.propname not in obj.__dict__:
             return self.proptype(self.default) if self.default is not None else None
         return obj.__dict__[self.propname]


### PR DESCRIPTION
This is a bit of a hack at the moment, but is a first attempt at some functionality I'd like to be in the pipeline. I've been using it to run grids of test jobs like this:
```bash
$ caput-pipeline template-run --var nside=128,256,512 --var redshift=10,30 testconv_za.yaml.tmpl
```

and the `.tmpl` file contains things like:
```yaml
    - type: draco.core.io.LoadBasicCont
      out: lss
      params:
        files:
          - lss_n{nside}.h5

    - type: cora.signal.lss.GenerateConstantBias
      in: lss
      out: biased
      params:
        bias: 0.0
        lightcone: false
        redshift: {redshift}
        output_name: bf_n{nside}_z{redshift}.h5
        save: true
```