### PR TITLE
feat(runner): add psutil based profiling to caput-pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install apt dependencies
         run: |
-          sudo apt-get install -y libopenmpi-dev openmpi-bin
+          sudo apt-get update && sudo apt-get install -y libopenmpi-dev openmpi-bin
 
       - name: Install pip dependencies
         run: |
@@ -47,7 +47,7 @@ jobs:
 
     - name: Install apt dependencies
       run: |
-        sudo apt-get install -y libopenmpi-dev openmpi-bin
+        sudo apt-get update && sudo apt-get install -y libopenmpi-dev openmpi-bin
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install pip dependencies
         run: |
-          pip install pylint==2.7.0 pylint-ignore flake8 pytest black mpi4py pyinstrument
+          pip install pylint==2.7.0 pylint-ignore flake8 pytest black mpi4py pyinstrument psutil
           pip install -r requirements.txt
           python setup.py develop
 
@@ -57,8 +57,7 @@ jobs:
     - name: Install pip dependencies
       run: |
         pip install -r requirements.txt
-        pip install mpi4py
-        pip install pytest
+        pip install mpi4py pytest psutil
         python setup.py develop
 
     - name: Run serial tests

--- a/caput/misc.py
+++ b/caput/misc.py
@@ -142,7 +142,7 @@ def scalarize(dtype=np.float64):
     return _scalarize_desc
 
 
-def listize(**base_kwargs):
+def listize(**_):
     """Make functions that already work with `np.ndarray` or scalars accept lists.
 
     Also works with tuples.

--- a/caput/misc.py
+++ b/caput/misc.py
@@ -45,7 +45,7 @@ def vectorize(**base_kwargs):
 
             return arr
 
-        def __get__(self, obj, type=None):
+        def __get__(self, obj, objtype=None):
 
             # As a descriptor, this gets called whenever this is used to wrap a
             # function, and simply binds it to the instance
@@ -53,7 +53,7 @@ def vectorize(**base_kwargs):
             if obj is None:
                 return self
 
-            new_func = self.func.__get__(obj, type)
+            new_func = self.func.__get__(obj, objtype)
             return self.__class__(new_func)
 
     return _vectorize_desc
@@ -128,7 +128,7 @@ def scalarize(dtype=np.float64):
 
             return (x, scalar, len(x) == 0)
 
-        def __get__(self, obj, type=None):
+        def __get__(self, obj, objtype=None):
 
             # As a descriptor, this gets called whenever this is used to wrap a
             # function, and simply binds it to the instance
@@ -136,7 +136,7 @@ def scalarize(dtype=np.float64):
             if obj is None:
                 return self
 
-            new_func = self.func.__get__(obj, type)
+            new_func = self.func.__get__(obj, objtype)
             return self.__class__(new_func)
 
     return _scalarize_desc
@@ -172,7 +172,7 @@ def listize(**base_kwargs):
 
             return self.func(*new_args, **kwargs)
 
-        def __get__(self, obj, type=None):
+        def __get__(self, obj, objtype=None):
 
             # As a descriptor, this gets called whenever this is used to wrap a
             # function, and simply binds it to the instance
@@ -180,7 +180,7 @@ def listize(**base_kwargs):
             if obj is None:
                 return self
 
-            new_func = self.func.__get__(obj, type)
+            new_func = self.func.__get__(obj, objtype)
             return self.__class__(new_func)
 
     return _listize_desc

--- a/caput/profile.py
+++ b/caput/profile.py
@@ -1,10 +1,14 @@
 """Helper routines for profiling the CPU and IO usage of code."""
 
 import math
+import time
 import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+import numpy as np
+import psutil
 
 from . import mpiutil
 
@@ -25,12 +29,12 @@ class Profiler:
         current directory.
     """
 
-    profilers = ["cProfile", "pyinstrument"]
+    profilers = ["cprofile", "pyinstrument"]
 
     def __init__(
         self,
         profile: bool = True,
-        profiler: str = "cProfile",
+        profiler: str = "cprofile",
         comm: Optional["mpiutil.MPI.IntraComm"] = None,
         path: Optional[os.PathLike] = None,
     ):
@@ -53,7 +57,7 @@ class Profiler:
         if not self.profile:
             return
 
-        if self.profiler == "cProfile":
+        if self.profiler == "cprofile":
             import cProfile
 
             self._pr = cProfile.Profile()
@@ -79,7 +83,7 @@ class Profiler:
 
         rank_length = int(math.log10(size)) + 1
 
-        if self.profiler == "cProfile":
+        if self.profiler == "cprofile":
             self._pr.disable()
             self._pr.dump_stats(f"profile_{rank:0{rank_length}}.prof")
 
@@ -118,8 +122,6 @@ class IOUsage:
     @staticmethod
     def _get_io():  # pylint: disable=no-self-use
         # Get the cumulative IO performed
-
-        import psutil
 
         if psutil.MACOS:
             d = psutil.disk_io_counters()
@@ -162,4 +164,288 @@ class IOUsage:
     @property
     def usage(self):
         """The IO usage within the block."""
+        return self._usage.copy()
+
+
+class PSUtilProfiler(psutil.Process):
+    """A context manager that profiles using psutil.
+
+    To access the profiling data the context manager object
+    must be created and bound to a variable *before* the *with* statement.
+
+    Dumps results into csv file, one for each rank.
+
+    >>> p = PSUtilProfiler(label='task-label')
+    >>> with p:
+    ...     print("do some task in here")
+    do some task in here
+    >>> print(p.usage)  #doctest: +ELLIPSIS
+    {...}
+
+    `start` and `stop` can be used to use the PSUtilProfiler outside of cotnext management.
+
+    >>> p = PSUtilProfiler(label='task-label')
+    >>> p.start()
+    >>> print('do some task in here')
+    do some task in here
+    >>> p.stop()
+    >>> print(p.usage) #doctest: +ELLIPSIS
+    {...}
+
+    Parameters
+    ----------
+    use_profiler : bool
+        Whether to run the profiler or not.
+    label : str
+        Default description of what is being profiled.
+    logger
+        If a logging object is passed the values of the IO done counters are logged
+        at INFO level.
+    comm
+        An optional MPI communicator. This is only used for labelling the output files.
+    path
+        The optional directory path under which to write the profile csvs.  If not set use the
+        current directory.
+    """
+
+    def __init__(
+        self,
+        use_profiler: bool = True,
+        label: str = "",
+        logger: Optional[logging.Logger] = None,
+        comm: Optional["mpiutil.MPI.IntraComm"] = None,
+        path: Optional[os.PathLike] = None,
+    ):
+        self._use_profiler = use_profiler
+        self._label = label
+        self._usage = {}
+        self._logger = logger
+        self.comm = comm
+
+        if self.comm is None:
+            rank = mpiutil.rank
+        else:
+            rank = self.comm.rank
+
+        if path is None:
+            self.path = Path.cwd()
+        else:
+            if not self.path.is_dir() or not self.path.exists():
+                raise ValueError(
+                    f"Make sure {self.path} passed to PSUtillProfiler is a directory that exists."
+                )
+            self.path = Path(path)
+
+        self.path = self.path / f"perf_{rank}.csv"
+
+        self._start_cpu_times = None
+        self._start_memory = None
+        self._start_disk_io = None
+        self._start_time = None
+
+        super().__init__()
+
+        if self._use_profiler and not self.path.exists():
+
+            import csv
+
+            with open(self.path, mode="w") as fp:
+
+                colnames = [
+                    "task_name",
+                    "time_s",
+                    "cpu_times_user",
+                    "cpu_times_system",
+                    "cpu_times_children_user",
+                    "cpu_times_children_system",
+                    "cpu_times_iowait",
+                    "average_cpu_load_percent",
+                    "disk_io_read_count",
+                    "disk_io_write_count",
+                    "disk_io_read_bytes",
+                    "disk_io_write_bytes",
+                    "disk_io_read_chars",
+                    "disk_io_write_chars",
+                    "memory_change_uss",
+                    "current_available_memory_bytes",
+                    "current_total_used_memory_bytes",
+                ]
+                cw = csv.writer(fp)
+                cw.writerow(colnames)
+
+        if self._use_profiler and self._logger:
+            self._logger.info(f"Profiling pipeline: {self.cpu_count} cores available.")
+
+    def __eq__(self, other):
+        if not isinstance(other, psutil.Process):
+            return False
+        return (
+            psutil.Process.__eq__(self, other)
+            and self._start_cpu_times == other._start_cpu_times
+            and self._start_memory == other._start_memory
+            and self._start_disk_io == other._start_disk_io
+            and self._start_time == other._start_time
+        )
+
+    def __enter__(self):
+        if not self._use_profiler:
+            return
+        self.start()
+
+    def __exit__(self, *args, **kwargs):
+        if not self._use_profiler:
+            return
+        self.stop()
+
+    def start(self):
+        """
+        Start profiling.
+
+        Results generated when `stop` is called are based on this start time.
+
+        """
+        self._start_time = time.time()
+
+        # Get all stats at the same time
+        with self.oneshot():
+            self._start_cpu_times = self.cpu_times()
+            self.cpu_percent()
+            self._start_memory = self.memory_full_info().uss
+            if psutil.MACOS:
+                self._start_memory = psutil.disk_io_counters()
+            else:
+                self._start_disk_io = self.io_counters()
+
+    def stop(self):
+        """
+        Stop profiler. Dump results to csv file and/or log and/or set results on self.usage.
+
+        `start` must be called first.
+
+        Returns
+        -------
+        Sets usage dictionary on `self` with the following attributes, under 'label' key.
+
+        cpu_times : `dict`
+            dict version of `psutil.cpu_times`. Process CPU times since `start` was called in seconds.
+        cpu_percent :  float
+            Process CPU utilization since `start` was called as percentage. Can be >100 if multiple threads run on
+            different cores. See `PSUtil.cpu_count` for available cores.
+        disk_io : `dict`
+            dict version of `psutil.io_counters` (on Linux) or `psutil.disk_io_counters` (on MacOS).
+            Difference since `start` was called.
+        memory : str
+            Difference of memory in use by this process since `start` was called. If negative,
+            less memory is in use now.
+        used_memory : str
+            Current used memory at the time of the task's end.
+        available_memory : str
+            Current memory available to the system at the time of the task's end.
+
+        Raises
+        ------
+        RuntimeError
+            If stop was called before start.
+        """
+        stop_time = time.time()
+
+        # Get all stats at the same time
+        with self.oneshot():
+            cpu_times = self.cpu_times()
+            cpu_percent = self.cpu_percent()
+            memory = self.memory_full_info().uss
+            used_memory = psutil.virtual_memory().used
+            available_memory = psutil.virtual_memory().available
+            if psutil.MACOS:
+                disk_io = psutil.disk_io_counters()
+            else:
+                disk_io = self.io_counters()
+
+        if self._start_cpu_times is None:
+            raise RuntimeError("PSUtilProfiler.stop was called before start.")
+
+        # Construct results
+        self._usage = {"task_name": self._label}
+
+        cpu_times_arr = np.subtract(cpu_times, self._start_cpu_times)
+        disk_io_arr = np.subtract(disk_io, self._start_disk_io)
+
+        cpu_times = {
+            k: v for (k, v) in zip(cpu_times._fields, cpu_times_arr)
+        }  # contain results in dictionary
+        disk_io = {
+            k: v for (k, v) in zip(disk_io._fields, disk_io_arr)
+        }  # contain results in dictionary
+
+        memory = memory - self._start_memory
+
+        self._usage["cpu_times"] = cpu_times
+        self._usage["cpu_percent"] = cpu_percent
+        self._usage["disk_io"] = disk_io
+
+        def bytes2human(num):
+            for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
+                if abs(num) < 1024.0:
+                    return f"{num:3.1f}{unit}B"
+                num /= 1024.0
+            return f"{num:.1f}YiB"
+
+        self._usage["memory"] = memory
+        self._usage["used_memory"] = used_memory
+        self._usage["available_memory"] = available_memory
+
+        time_s = stop_time - self._start_time
+
+        self._usage["time_s"] = time_s
+
+        if time_s < 0.1 and self._logger:
+            self._logger.info(
+                f"{self._label} ran for {time_s:.4f} < 0.1s, results might be inaccurate.\n"
+            )
+
+        if self._logger:
+            self._logger.info(f"{self._label} ran for {time_s:.4f}s")
+            self._logger.info(f"{cpu_times}")
+            self._logger.info(f"average CPU load: {cpu_percent}")
+            self._logger.info(f"{disk_io}")
+            self._logger.info(f"change in (uss) memory: {bytes2human(memory)}")
+            self._logger.info(
+                f"current available memory: {bytes2human(available_memory)}"
+            )
+            self._logger.info(f"current total used memory: {bytes2human(used_memory)}")
+
+        with open(self.path, mode="a", newline="") as fp:
+            import csv
+
+            cw = csv.writer(fp)
+            cw.writerow(
+                [
+                    self._label,
+                    time_s,
+                    cpu_times["user"],
+                    cpu_times["system"],
+                    cpu_times["children_user"],
+                    cpu_times["children_system"],
+                    cpu_times["iowait"],
+                    cpu_percent,
+                    disk_io["read_count"],
+                    disk_io["write_count"],
+                    disk_io["read_bytes"],
+                    disk_io["write_bytes"],
+                    disk_io["read_chars"],
+                    disk_io["write_chars"],
+                    memory,
+                    available_memory,
+                    used_memory,
+                ]
+            )
+
+    @property
+    def cpu_count(self):
+        """Number of cores available to this process."""
+        return len(self.cpu_affinity())
+
+    @property
+    def usage(self):
+        """The memory and cpu usage within the block."""
         return self._usage.copy()

--- a/caput/tests/test_pipeline.py
+++ b/caput/tests/test_pipeline.py
@@ -1,39 +1,9 @@
 """Test running the caput.pipeline."""
-import tempfile
-
-from caput.scripts.runner import cli
-
-eggs_conf = """
----
-pipeline:
-  tasks:
-    - type: caput.tests.conftest.PrintEggs
-      params: eggs_params
-
-    - type: caput.tests.conftest.GetEggs
-      params: eggs_params
-      out: egg
-
-    - type: caput.tests.conftest.CookEggs
-      params: cook_params
-      in: egg
-
-eggs_params:
-  eggs: ['green', 'duck', 'ostrich']
-
-cook_params:
-  style: 'fried'
-"""
+from caput.tests import conftest
 
 
 def test_pipeline():
     """Test running a very simple pipeline."""
-    with tempfile.NamedTemporaryFile("w+") as configfile:
-        configfile.write(eggs_conf)
-        configfile.flush()
-        from click.testing import CliRunner
-
-        runner = CliRunner()
-        result = runner.invoke(cli, ["run", configfile.name])
-        print(result.output)
-        assert result.exit_code == 0
+    result = conftest.run_pipeline()
+    print(result.output)
+    assert result.exit_code == 0

--- a/caput/tests/test_psutilprofiler.py
+++ b/caput/tests/test_psutilprofiler.py
@@ -1,0 +1,10 @@
+"""Test running the caput.pipeline."""
+
+from caput.tests import conftest
+
+
+def test_pipeline():
+    """Test profiling a very simple pipeline."""
+    result = conftest.run_pipeline(["--psutil"])
+    print(result.output)
+    assert result.exit_code == 0

--- a/caput/time.py
+++ b/caput/time.py
@@ -1171,7 +1171,7 @@ def _solve_all(f, x0, x1, dx, skip_increasing=False, skip_decreasing=False, **kw
         roots.append(root)
         increasing.append(is_increasing)
 
-    return (np.array(roots, dtype=np.float64), np.array(increasing, dtype=np.bool))
+    return (np.array(roots, dtype=np.float64), np.array(increasing, dtype=bool))
 
 
 def skyfield_star_from_ra_dec(ra, dec, name=""):

--- a/caput/weighted_median.pyx
+++ b/caput/weighted_median.pyx
@@ -276,7 +276,7 @@ def quantile(A, W, q, method="split"):
     if A.dtype == np.intc:
         if W.dtype == np.intc:
             _quickselect[int, int](Ar, Wr, q, methodc, res, At, Wt)
-        elif W.dtype == np.int:
+        elif W.dtype == int:
             _quickselect[int, long](Ar, Wr, q, methodc, res, At, Wt)
         elif W.dtype == np.single:
             _quickselect[int, float](Ar, Wr, q, methodc, res, At, Wt)
@@ -284,10 +284,10 @@ def quantile(A, W, q, method="split"):
             _quickselect[int, double](Ar, Wr, q, methodc, res, At, Wt)
         else:
             raise TypeError("Type of weight array is not supported.")
-    elif A.dtype == np.int:
+    elif A.dtype == int:
         if W.dtype == np.intc:
             _quickselect[long, int](Ar, Wr, q, methodc, res, At, Wt)
-        elif W.dtype == np.int:
+        elif W.dtype == int:
             _quickselect[long, long](Ar, Wr, q, methodc, res, At, Wt)
         elif W.dtype == np.single:
             _quickselect[long, float](Ar, Wr, q, methodc, res, At, Wt)
@@ -298,7 +298,7 @@ def quantile(A, W, q, method="split"):
     elif A.dtype == np.single:
         if W.dtype == np.intc:
             _quickselect[float, int](Ar, Wr, q, methodc, res, At, Wt)
-        elif W.dtype == np.int:
+        elif W.dtype == int:
             _quickselect[float, long](Ar, Wr, q, methodc, res, At, Wt)
         elif W.dtype == np.single:
             _quickselect[float, float](Ar, Wr, q, methodc, res, At, Wt)
@@ -309,7 +309,7 @@ def quantile(A, W, q, method="split"):
     elif A.dtype == np.double:
         if W.dtype == np.intc:
             _quickselect[double, int](Ar, Wr, q, methodc, res, At, Wt)
-        elif W.dtype == np.int:
+        elif W.dtype == int:
             _quickselect[double, long](Ar, Wr, q, methodc, res, At, Wt)
         elif W.dtype == np.single:
             _quickselect[double, float](Ar, Wr, q, methodc, res, At, Wt)

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     """,
     python_requires=">=3.6",
     install_requires=requires,
-    extras_require={"mpi": ["mpi4py>=1.3"]},
+    extras_require={"mpi": ["mpi4py>=1.3"], "profiling": ["psutil", "pyinstrument"]},
     setup_requires=["cython"],
     # metadata for upload to PyPI
     author="Kiyo Masui, J. Richard Shaw",


### PR DESCRIPTION
To turn on profiling with psutil, pass the flag `--psutil` with pipeline `queue` or `run`.

The profiling results will be saved to csv files, one for each rank, in the pipeline's `work_dir` as `perf_{rank}.csv`. 