### PR TITLE
fix(mpiarray): ensure global_shape for new MPIArray is a tuple

### DIFF
--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -369,7 +369,7 @@ class MPIArray(np.ndarray):
         arr = np.ndarray.__new__(cls, lshape, *args, **kwargs)
 
         # Set attributes of class
-        arr._global_shape = global_shape
+        arr._global_shape = tuple(global_shape)
         arr._axis = axis
         arr._local_shape = tuple(lshape)
         arr._local_offset = tuple(loffset)


### PR DESCRIPTION
When following the code-threads for [this issue](https://github.com/radiocosmology/caput/issues/186), it became clear that `MPIArray` never asserts that the `global_shape` it receives is a tuple, when initially creating an `MPIArray`. This could result in [problems](https://github.com/radiocosmology/caput/issues/186), when referencing a container `dataset`, since they pull the `MemDatasetDistributed`'s `shape` from its `MPIArray's` `_global_shape`.

We may want to add `typing` information to `MPIArray`, opening PR to see if we want to do that.

At the moment, I still did not know who is changing the `tuple shape` from the original container's dataset, to the `list shape` in the `containers.empty_like` container.

