### PR TITLE
Remove Nyquist frequency from PFB

### DIFF
--- a/caput/pfb.py
+++ b/caput/pfb.py
@@ -137,7 +137,7 @@ class PFB:
             ft = np.fft.rfft(ts_sec * w)
 
             # Choose every n-th frequency
-            spec[bi] = ft[:: self.ntap]
+            spec[bi] = ft[: ((self.lblock // 2) * self.ntap) : self.ntap]
 
         return spec
 


### PR DESCRIPTION
Don't know why this didn't get merged a long time ago -- based on Richard's suggestion here:
https://github.com/radiocosmology/caput/issues/173