### PR TITLE
MPIArray cleanups and speedups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install apt dependencies
         run: |
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: ["3.7", "3.10"]
 
     runs-on: ubuntu-latest
     steps:
@@ -83,10 +83,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Install apt dependencies
       run: |

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -1389,7 +1389,14 @@ class MemDatasetDistributed(MemDataset):
         axis : integer
             Axis to distribute over.
         """
-        self._data = self._data.redistribute(axis=axis)
+        if self._storage_root is not None:
+            # This is a view, and we should modify the base dataset
+            base_dset = self._storage_root[self.name]
+            base_dset.redistribute(axis=axis)
+            self._data = base_dset._data
+        else:
+            # This is the the base dataset, call the MPIArray redistribution
+            self._data = self._data.redistribute(axis=axis)
 
     def __getitem__(self, obj):
         return self._data.global_slice[obj]

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -414,16 +414,18 @@ class MPIArray(np.ndarray):
 
             if isinstance(dist_axis_index, int):
                 warnings.warn(
-                    "You are indexing directly into the distributed axis."
-                    "Returning a view into the local array."
-                    "Please use global_slice, or .local_array before indexing instead."
+                    "You are indexing directly into the distributed axis "
+                    "returning a view into the local array. "
+                    "Please use global_slice, or .local_array before indexing instead.",
+                    stacklevel=2,
                 )
 
                 return self.local_array.__getitem__(v)
             warnings.warn(
-                "You are directly sub-slicing the distributed axis."
-                "Returning a view into the local array."
-                "Please use global_slice, or .local_array before indexing."
+                "You are directly sub-slicing the distributed axis "
+                "returning a view into the local array. "
+                "Please use global_slice, or .local_array before indexing.",
+                stacklevel=2,
             )
             return self.local_array.__getitem__(v)
 
@@ -1791,7 +1793,8 @@ class MPIArray(np.ndarray):
                         "A ufunc is combining an MPIArray with a numpy array that "
                         "matches exactly the local part of the distributed axis. This "
                         "is very fragile and may fail on other ranks. "
-                        f"Numpy array shape: {inp.shape}; dist axis: {cur_dist_axis}."
+                        f"Numpy array shape: {inp.shape}; dist axis: {cur_dist_axis}.",
+                        stacklevel=3,
                     )
                 elif cur_axis_length != 1:
                     raise AxisException(

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1827,8 +1827,8 @@ class MPIArray(np.ndarray):
 
         return (
             final_dist_axis,
-            input_.global_shape[final_dist_axis],
-            input_.local_offset[final_dist_axis],
+            input_.global_shape[input_.axis],
+            input_.local_offset[input_.axis],
         )
 
     # pylint: enable=inconsistent-return-statements

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1709,6 +1709,12 @@ class MPIArray(np.ndarray):
         # arrays
         if "out" in kwargs:
             out_args = kwargs.get("out", None)
+            if not all(isinstance(x, MPIArray) for x in out_args):
+                raise TypeError(
+                    "At least one output is not an MPIArray. This can happen if a ufunc "
+                    "is trying to modify a np.ndarray in-place using values from a MPIArray. "
+                    "Try using .local_array or cast the np.ndarray to MPIArray."
+                )
             kwargs["out"] = _mpi_to_ndarray(out_args, only_mpiarray=True)
 
             # Check the distribution of the output arguments makes sense

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1465,7 +1465,25 @@ class MPIArray(np.ndarray):
 
         return arr
 
+    def copy(self, *args, **kwargs):
+        """Return a copy of the MPIArray.
+
+        Returns
+        -------
+        arr_copy : MPIArray
+        """
+        return MPIArray.wrap(
+            self.view(np.ndarray).copy(*args, **kwargs), axis=self.axis, comm=self.comm
+        )
+
     def ravel(self, *args, **kwargs):
+        """This method is explicitly not implemented and will
+        return a NotImplementedError.
+
+        Raises
+        ------
+        NotImplementedError
+        """
         raise NotImplementedError(
             "Method 'ravel' is not implemented for distributed arrays. "
             "Try using '.local_array'."
@@ -1873,8 +1891,6 @@ class MPIArray(np.ndarray):
             raise AxisException(
                 f"Distributed axis {axis} does not exist in global shape {global_shape}"
             ) from e
-
-        print(global_shape, axis, axlen)
 
         global_shape[axis] = axlen
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1378,25 +1378,6 @@ class MPIArray(np.ndarray):
 
         return rdata
 
-    # def copy(self, *args, **kwargs):
-    #     """Return a copy of the MPIArray.
-
-    #     Returns
-    #     -------
-    #     arr_copy : MPIArray
-    #     """
-    #     # global_len = len(self.view(np.ndarray)[self.axis])
-    #     # local_start = 0
-
-    #     return MPIArray.wrap(
-    #     # return MPIArray._view_from_data_and_params(
-    #         self.view(np.ndarray).copy(*args, **kwargs), axis=self.axis, 
-    #         # global_length=global_len,
-    #         # local_start=local_start,
-    #         comm=self.comm,
-
-    #     )
-
     def gather(self, rank=0):
         """Gather a full copy onto a specific rank.
 
@@ -1483,6 +1464,12 @@ class MPIArray(np.ndarray):
             arr[tuple(dest_slice)] = tbuf
 
         return arr
+
+    def ravel(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Method 'ravel' is not implemented for distributed arrays. "
+            "Try using '.local_array'."
+        )
 
     def _to_hdf5_serial(self, filename, dataset, create=False):
         """Write into an HDF5 dataset.
@@ -1666,7 +1653,6 @@ class MPIArray(np.ndarray):
         # validates the inputs and arguments are appropriate (same distributed axis
         # etc.), and infers and returns the parameters of the output distributed axis
         # (i.e. it's position, length and the offset on this rank)
-        print(ufunc, method)
 
         _validation_fn = {
             "__call__": self._array_ufunc_call,

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1896,6 +1896,46 @@ class MPIArray(np.ndarray):
         return
 
 
+def zeros(*args, **kwargs) -> MPIArray:
+    """Generate an MPIArray filled with zeros.
+
+    Parameters
+    ----------
+    args, kwargs
+        Arguments passed straight through to the `MPIArray` constructor.
+
+    Returns
+    -------
+    MPIArray
+        The filled MPIArray.
+    """
+
+    arr = MPIArray(*args, **kwargs)
+    arr[:] = 0
+
+    return arr
+
+
+def ones(*args, **kwargs) -> MPIArray:
+    """Generate an MPIArray filled with ones.
+
+    Parameters
+    ----------
+    args, kwargs
+        Arguments passed straight through to the `MPIArray` constructor.
+
+    Returns
+    -------
+    MPIArray
+        The filled MPIArray.
+    """
+
+    arr = MPIArray(*args, **kwargs)
+    arr[:] = 1
+
+    return arr
+
+
 def _partition_sel(sel, split_axis, n, slice_):
     """
     Re-slice a selection along a new axis.

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -884,7 +884,7 @@ class MPIArray(np.ndarray):
                 f"rank, but rank={self.comm.rank} has shape-{self.local_shape}."
             )
 
-        result_arr = np.zeros_like(self)
+        result_arr = np.zeros((1,), dtype=self.dtype)
         self.comm.Allreduce(self, result_arr, MPI.SUM if op is None else op)
         return result_arr[0]
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1378,16 +1378,24 @@ class MPIArray(np.ndarray):
 
         return rdata
 
-    def copy(self):
-        """Return a copy of the MPIArray.
+    # def copy(self, *args, **kwargs):
+    #     """Return a copy of the MPIArray.
 
-        Returns
-        -------
-        arr_copy : MPIArray
-        """
-        return MPIArray.wrap(
-            self.view(np.ndarray).copy(), axis=self.axis, comm=self.comm
-        )
+    #     Returns
+    #     -------
+    #     arr_copy : MPIArray
+    #     """
+    #     # global_len = len(self.view(np.ndarray)[self.axis])
+    #     # local_start = 0
+
+    #     return MPIArray.wrap(
+    #     # return MPIArray._view_from_data_and_params(
+    #         self.view(np.ndarray).copy(*args, **kwargs), axis=self.axis, 
+    #         # global_length=global_len,
+    #         # local_start=local_start,
+    #         comm=self.comm,
+
+    #     )
 
     def gather(self, rank=0):
         """Gather a full copy onto a specific rank.
@@ -1658,6 +1666,8 @@ class MPIArray(np.ndarray):
         # validates the inputs and arguments are appropriate (same distributed axis
         # etc.), and infers and returns the parameters of the output distributed axis
         # (i.e. it's position, length and the offset on this rank)
+        print(ufunc, method)
+
         _validation_fn = {
             "__call__": self._array_ufunc_call,
             "accumulate": self._array_ufunc_accumulate,
@@ -1670,7 +1680,6 @@ class MPIArray(np.ndarray):
                 "using `.local_array` to convert to a pure numpy array first, and the "
                 "use `MPIArray.wrap` to reconstruct an MPIArray at the end."
             )
-
         # Where arguments are not supported, except where the value is a simple `True`,
         # which is used as a default
         if "where" in kwargs and not (
@@ -1878,6 +1887,8 @@ class MPIArray(np.ndarray):
             raise AxisException(
                 f"Distributed axis {axis} does not exist in global shape {global_shape}"
             ) from e
+
+        print(global_shape, axis, axlen)
 
         global_shape[axis] = axlen
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -486,7 +486,7 @@ def test_global_setslice():
     assert (darr_float == 4.0).all()
 
 
-def test_outer_ufunc():
+def test_call_ufunc():
     rank = mpiutil.rank
     size = mpiutil.size
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -554,6 +554,35 @@ def test_ufunc_broadcast():
     dist_arr3 = dist_arr1 + dist_arr2
     assert (dist_arr3 == 2 * dist_arr1).all()
 
+    # Test a broadcast against a numpy array of the same dimensionality
+    nondist_arr = 2 * np.ones((4, 1))
+    assert (dist_arr1 * nondist_arr == 2 * rank).all()
+
+    # Test a broadcast against a numpy array of the same dimensionality, but with a
+    # mismatch on the "distributed" axis. This should fail
+    nondist_arr = np.ones((4, 3))
+    with pytest.raises(ValueError):
+        _ = dist_arr1 * nondist_arr
+
+    # Test a broadcast against a numpy array of lower dimensionality, with the
+    # distributed axis being one of the axes on the non distributed array
+    nondist_arr = 2 * np.ones((1,))
+    assert (dist_arr1 * nondist_arr == 2 * rank).all()
+
+    # Test a broadcast against a numpy array of lower dimensionality, with the
+    # distributed axis being one of the axes implicitly added to the numpy array
+    dist_arr3 = mpiarray.MPIArray((size, 4), axis=0)
+    dist_arr3.local_array[:] = rank
+    nondist_arr = 2 * np.ones((4,))
+    assert (dist_arr3 * nondist_arr == 2 * rank).all()
+
+    # Test a broadcast against a numpy array of higher dimensionality, with the
+    # distributed axis being one of the axes on the non distributed array
+    nondist_arr = 2 * np.ones((1, 4, 1))
+    t = dist_arr1 * nondist_arr
+    assert t.global_shape == (1, 4, size)
+    assert (t == 2 * rank).all()
+
 
 def test_ufunc_2output():
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -4,7 +4,7 @@ Designed to be run as an MPI job with four processes like::
 
     $ mpirun -np 4 python test_mpiarray.py
 """
-from typing import Union, Any
+from typing import Union
 import pytest
 from pytest_lazyfixture import lazy_fixture
 import h5py
@@ -40,7 +40,8 @@ def test_construction():
 
 
 @pytest.mark.parametrize(
-    "dtype", [np.int64, np.float32, pytest.param("U16", marks=pytest.mark.xfail)]
+    "dtype",
+    [np.int64, np.float32, "U16"],
 )
 def test_redistribution(dtype):
     """Test redistributing an MPIArray."""

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -43,10 +43,10 @@ def test_redistribution():
     arr[:] = garr[:, s0:e0]
 
     arr2 = arr.redistribute(axis=3)
-    assert (arr2 == garr[:, :, :, s1:e1]).view(np.ndarray).all()
+    assert (arr2.local_array == garr[:, :, :, s1:e1]).all()
 
     arr3 = arr.redistribute(axis=5)
-    assert (arr3 == garr[:, :, :, :, :, s2:e2]).view(np.ndarray).all()
+    assert (arr3.local_array == garr[:, :, :, :, :, s2:e2]).all()
 
 
 def test_gather():
@@ -303,7 +303,7 @@ def test_global_getslice():
     local_array_T = whole_array[:, (rank * 5) : ((rank + 1) * 5)]
 
     # Check that these are the same
-    assert (local_array == darr).all()
+    assert (local_array == darr.local_array).all()
 
     # Check a simple slice on the non-parallel axis
     arr = darr.global_slice[:, 3:5]
@@ -311,12 +311,12 @@ def test_global_getslice():
 
     assert isinstance(arr, mpiarray.MPIArray)
     assert arr.axis == 0
-    assert (arr == res).all()
+    assert (arr.local_array == res).all()
 
     # Check a single element extracted from the non-parallel axis
     arr = darr.global_slice[:, 3]
     res = local_array[:, 3]
-    assert (arr == res).all()
+    assert (arr.local_array == res).all()
 
     # Check that slices contain MPIArray attributes
     assert hasattr(arr, "comm") and (arr.comm == darr.comm)
@@ -446,25 +446,25 @@ def test_global_setslice():
     darr.global_slice[:, 6] = -2.0
     local_array[:, 6] = -2.0
 
-    assert (darr == local_array).all()
+    assert (darr.local_array == local_array).all()
 
     # Check a partial assignment along the parallel axis
     darr.global_slice[7:, 7:9] = -3.0
     whole_array[7:, 7:9] = -3.0
 
-    assert (darr == local_array).all()
+    assert (darr.local_array == local_array).all()
 
     # Check assignment of a single index on the parallel axis
     darr.global_slice[6] = np.arange(20.0)
     whole_array[6] = np.arange(20.0)
 
-    assert (darr == local_array).all()
+    assert (darr.local_array == local_array).all()
 
     # Check copy of one column into the other
     darr.global_slice[:, 8] = darr.global_slice[:, 9]
     whole_array[:, 8] = whole_array[:, 9]
 
-    assert (darr == local_array).all()
+    assert (darr.local_array == local_array).all()
 
     # test setting complex dtypes
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -249,6 +249,26 @@ def test_transpose():
     assert arr4.axis == 2
 
 
+def test_copy():
+    # Test that standard numpy.copy() method works
+    # for MPIArrays
+    size = mpiutil.size
+
+    arr = mpiarray.ones((3, size, 14), axis=1, dtype=np.float32)
+    arr2 = arr.copy()
+
+    assert (arr == arr2).all()
+
+    # Check type
+    assert isinstance(arr2, mpiarray.MPIArray)
+
+    # Check global shape
+    assert arr.global_shape == arr2.global_shape
+
+    # Check axis
+    assert arr2.axis == 1
+
+
 def test_reshape():
 
     gshape = (1, 11, 2, 14)
@@ -848,7 +868,7 @@ def test_mpi_array_fill():
     assert arr_ones.dtype == int
 
 
-def test_ravel():
+def test_call_ravel():
     size = mpiutil.size
 
     arr_ones = mpiarray.ones((4, size, 17), axis=1)
@@ -856,7 +876,7 @@ def test_ravel():
         arr_ones.ravel()
 
 
-def test_median():
+def test_call_median():
     size = mpiutil.size
 
     arr_ones = mpiarray.ones((4, size, 17), axis=1)

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -860,7 +860,12 @@ def test_median():
     size = mpiutil.size
 
     arr_ones = mpiarray.ones((4, size, 17), axis=1)
-    with pytest.raises(NotImplementedError):
+    # Check that this will fail correctly when trying to
+    # take median across the distributed axis
+    with pytest.raises(mpiarray.AxisException):
         np.median(arr_ones, axis=1)
-    
-    np.median(arr_ones.local_array, axis=1)
+    # Check that the median fails due to .ravel() call
+    with pytest.raises(NotImplementedError):
+        np.median(arr_ones, axis=0)
+    # Check that median call with local array works
+    assert (np.median(arr_ones.local_array, axis=0) == np.ones(arr_ones.shape)).all()

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -638,18 +638,20 @@ def test_ufunc_reduce():
 
     # sum across a smaller numbered axes
     # this will result in an axes reduction
-    dist_array = mpiarray.MPIArray((size, 4, 3), axis=1)
+    dist_array = mpiarray.MPIArray((5, size, 3), axis=1)
     dist_array[:] = rank
 
-    assert (dist_array.sum(axis=0) == 4 * rank).all()
+    sum_array_0 = dist_array.sum(axis=0)
+    assert (sum_array_0 == 5 * rank).all()
 
     # check that the new axes was calculated accordingly
-    assert (dist_array.sum(axis=0)).axis == 0
+    assert sum_array_0.axis == 0
+    assert sum_array_0.global_shape == (size, 3)
 
     assert dist_array.sum(axis=0, keepdims=True).axis == 1
 
     sum_all = dist_array.sum()
-    assert (sum_all == 4 * 3 * rank).all()
+    assert (sum_all == 5 * 3 * rank).all()
 
     assert sum_all.local_shape == (1,)
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -824,3 +824,25 @@ def test_slice_npint64():
     assert new_dist_array.shape == (1, 3)
     assert new_dist_array.global_shape == (size, 3)
     assert (new_dist_array[:] == rank).all()
+
+
+def test_mpi_array_fill():
+
+    rank = mpiutil.rank
+    size = mpiutil.size
+
+    arr_zero = mpiarray.zeros((4, size, 17), axis=1, dtype=np.float32)
+    assert (arr_zero == 0).all()
+    assert arr_zero.axis == 1
+    assert arr_zero.global_shape == (4, size, 17)
+    assert arr_zero.shape == (4, 1, 17)
+    assert arr_zero.local_offset == (0, rank, 0)
+    assert arr_zero.dtype == np.float32
+
+    arr_ones = mpiarray.ones((4, size, 17), axis=1, dtype=int)
+    assert (arr_ones == 1).all()
+    assert arr_ones.axis == 1
+    assert arr_ones.global_shape == (4, size, 17)
+    assert arr_ones.shape == (4, 1, 17)
+    assert arr_ones.local_offset == (0, rank, 0)
+    assert arr_ones.dtype == int

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -846,3 +846,21 @@ def test_mpi_array_fill():
     assert arr_ones.shape == (4, 1, 17)
     assert arr_ones.local_offset == (0, rank, 0)
     assert arr_ones.dtype == int
+
+
+def test_ravel():
+    size = mpiutil.size
+
+    arr_ones = mpiarray.ones((4, size, 17), axis=1)
+    with pytest.raises(NotImplementedError):
+        arr_ones.ravel()
+
+
+def test_median():
+    size = mpiutil.size
+
+    arr_ones = mpiarray.ones((4, size, 17), axis=1)
+    with pytest.raises(NotImplementedError):
+        np.median(arr_ones, axis=1)
+    
+    np.median(arr_ones.local_array, axis=1)

--- a/caput/tests/test_selection_parallel.py
+++ b/caput/tests/test_selection_parallel.py
@@ -103,5 +103,5 @@ def test_FileSelect_distributed(container_on_disk, fsel, isel, file_format, ind)
     #         print(d2[d2slice][0, :2] if d2[d2slice].size else "Empty")
     #     comm.Barrier()
 
-    assert np.all(m["dset1"][:] == d1[d1slice])
-    assert np.all(m["dset2"][:] == d2[d2slice])
+    assert np.all(m["dset1"][:].local_array == d1[d1slice])
+    assert np.all(m["dset2"][:].local_array == d2[d2slice])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 click
 cython
 h5py
-numpy>=1.16
+numpy>=1.20
 psutil
 PyYAML
 scipy

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         [console_scripts]
         caput-pipeline=caput.scripts.runner:cli
     """,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requires,
     extras_require={
         "mpi": ["mpi4py>=1.3"],


### PR DESCRIPTION
- test(mpiarray): tests actually cover __call__ ufuncs not outer ones
- test(mpiarray): check reductions over multiple axes
- test(mpiarray): increase test coverage
- fix(mpiarray): address ufunc corner cases and remove unncessary MPI calls
