### PR TITLE
Add explicit TypeError when ufunc tries to output to a numpy array

### DIFF
--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1703,6 +1703,12 @@ class MPIArray(np.ndarray):
         # arrays
         if "out" in kwargs:
             out_args = kwargs.get("out", None)
+            if not all(isinstance(x, MPIArray) for x in out_args):
+                raise TypeError(
+                    "At least one output is not an MPIArray. This can happen if a ufunc "
+                    "is trying to modify a np.array in-place using values from a MPIArray. "
+                    "Try using .local_array or cast the np.array to MPIArray."
+                )
             kwargs["out"] = _mpi_to_ndarray(out_args, only_mpiarray=True)
 
             # Check the distribution of the output arguments makes sense

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1706,8 +1706,8 @@ class MPIArray(np.ndarray):
             if not all(isinstance(x, MPIArray) for x in out_args):
                 raise TypeError(
                     "At least one output is not an MPIArray. This can happen if a ufunc "
-                    "is trying to modify a np.array in-place using values from a MPIArray. "
-                    "Try using .local_array or cast the np.array to MPIArray."
+                    "is trying to modify a np.ndarray in-place using values from a MPIArray. "
+                    "Try using .local_array or cast the np.ndarray to MPIArray."
                 )
             kwargs["out"] = _mpi_to_ndarray(out_args, only_mpiarray=True)
 


### PR DESCRIPTION
Although this should be fixed everywhere in the pipeline at the moment, it is not very clear that the actual error that ends up getting thrown is caused by this specifically. This check might help us in the future by making it clear what is going on.