### PR TITLE
fix(tod): issues copying data from h5py datasets

### DIFF
--- a/caput/tod.py
+++ b/caput/tod.py
@@ -579,6 +579,7 @@ def _copy_non_time_data(
     # datasets, and which are items we need to copy
     to_copy = []
     stack = [data]
+
     while stack:
 
         entry = stack.pop()
@@ -608,9 +609,9 @@ def _copy_non_time_data(
                 target = out if entry.name == "/" else out.require_group(entry.name)
             else:
                 arr = (
-                    memh5.ensure_unicode(entry.data)
+                    memh5.ensure_unicode(entry[:])
                     if convert_dataset_strings
-                    else entry.data
+                    else entry[:]
                 )
                 target = out.create_dataset(
                     entry.name,
@@ -632,8 +633,9 @@ def _dset_has_axis(entry: Any, axes: Tuple[str]) -> bool:
     if memh5.is_group(entry):
         return False
 
-    # Assume is a dataset
-    dset_axes = entry.attrs.get("axis", ())
+    # Assume is a dataset. We need to ensure the output strings are Unicode as h5py may
+    # return them as byte strings if the input is an h5py.Dataset
+    dset_axes = memh5.bytes_to_unicode(entry.attrs.get("axis", ()))
 
     return len(set(dset_axes).intersection(axes)) > 0
 


### PR DESCRIPTION
I'm putting this one in separately as it's currently breaking all of ch_utils tests.

There were two main issues in here:
- The newly refactored method was trying to access the `.data` attribute, but that's not available when copying an `h5py.Dataset`. Switching to `[:]` should be equivalent, albeit a little slower for the `MemDataset`'s.
- `h5py` returns attributes as bytestrings as so the lookup for time axes was failing as we pass them in as unicode strings. This explicitly converts the strings from the dataset.