### PR TITLE
build(setup.py, .github/workflows/main.yml): un-pin numcodecs version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         pip install h5py
         pip install -r requirements.txt
         pip install zarr==2.8.1
-        pip install mpi4py numcodecs==0.7.3 bitshuffle
+        pip install mpi4py numcodecs>=0.7.3 bitshuffle
         pip install pytest pytest-lazy-fixture
         python setup.py develop
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "mpi": ["mpi4py>=1.3"],
         "compression": [
             "bitshuffle",
-            "numcodecs==0.7.3",
+            "numcodecs>=0.7.3",
             "zarr==2.8.1",
         ],
         "profiling": ["psutil", "pyinstrument"],


### PR DESCRIPTION
`numcodecs 0.7.3` uses a version of `py-cpuinfo` that does not support Apple Silicon. Newer versions of `numcodecs` don't have this issue, so if possible, we should not pin to 0.7.3.