### PR TITLE
Reduce memory used by `MPIArray.redistribute`

### DIFF
--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -62,6 +62,10 @@ def test_redistribution(dtype):
     arr3 = arr.redistribute(axis=5)
     assert (arr3.local_array == garr[:, :, :, :, :, s2:e2]).all()
 
+    assert arr.local_array.flags.c_contiguous
+    assert arr2.local_array.flags.c_contiguous
+    assert arr3.local_array.flags.c_contiguous
+
 
 @pytest.mark.parametrize(
     "dtype",


### PR DESCRIPTION
Modifies `MPIArray.redistribute` method to reduce overall memory use. This is accomplished by passing messages cyclically to the `i` adjacent neighbour for `i` total ranks, letting us use only one send and one receive buffer at a time.