### PR TITLE
perf(moving_weighted_median): transpose 2D array if window size [0] is less than size[1]

### DIFF
--- a/caput/weighted_median.pyx
+++ b/caput/weighted_median.pyx
@@ -355,20 +355,32 @@ def weighted_median(A, W, method="split"):
 
 def _check_arrays(data, weights):
 
-    # make sure this is numpy arrays
+    # make sure these are numpy arrays
     if not isinstance(data, np.ndarray):
         data = np.array(data, dtype=np.float64)
     if not isinstance(weights, np.ndarray):
         weights = np.array(weights, dtype=np.float64)
 
-    if data.dtype != np.dtype(np.float64):
-        raise ValueError('Expected data to be numpy.float64 (got {}).'.format(data.dtype))
-    if weights.dtype != np.dtype(np.float64):
-        raise ValueError('Expected weights to be numpy.float64 (got {}).'
-                         .format(weights.dtype))
+    # Ensure data is numeric
+    if not np.issubdtype(data.dtype, np.number):
+        raise ValueError(
+            f"Data must be a subdtype of numpy.number (got {data.dtype})"
+        )
+    if not np.issubdtype(weights.dtype, np.number):
+        raise ValueError(
+            f"Weights must be a subdtype of numpy.number (got {weights.dtype})"
+        )
+    # Ensure data is not complex
+    if np.iscomplexobj(data):
+        raise ValueError(f"Data must be real (got {data.dtype})")
+    if np.iscomplexobj(weights):
+        raise ValueError(f"Weights must be real (got {weights.dtype})")
+
     if data.ndim != weights.ndim:
-        raise ValueError('Expected data and weights to have same dimensions (is {} and {}).'
-                         .format(data.ndim, weights.ndim))
+        raise ValueError(
+            f"Expected data and weights to have same dimensions "
+            f"(is {data.ndim} and {weights.ndim})."
+        )
 
     return data, weights
 
@@ -444,7 +456,7 @@ def moving_weighted_median(data, weights, size, method="split"):
                          .format(data.ndim))
 
 
-def _mwm_1D(np.ndarray[np.float64_t, ndim=1] data, np.ndarray[np.float64_t, ndim=1] weights, size,
+def _mwm_1D(np.ndarray[data_t, ndim=1] data, np.ndarray[weight_t, ndim=1] weights, size,
             method):
 
     cdef Py_ssize_t len_data = data.shape[0]
@@ -490,7 +502,7 @@ def _mwm_1D(np.ndarray[np.float64_t, ndim=1] data, np.ndarray[np.float64_t, ndim
 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
-def _mwm_2D(np.ndarray[np.float64_t, ndim=2] data, np.ndarray[np.float64_t, ndim=2] weights, size,
+def _mwm_2D(np.ndarray[data_t, ndim=2] data, np.ndarray[weight_t, ndim=2] weights, size,
             char method):
 
     # The 2D moving window goes through the matrix row-by-row, to simplify keeping track of

--- a/caput/weighted_median.pyx
+++ b/caput/weighted_median.pyx
@@ -450,8 +450,13 @@ def moving_weighted_median(data, weights, size, method="split"):
     if data.ndim == 2:
         if any(np.asarray(size) % 2 == 0):
             raise ValueError('Need an uneven window size (got {}).'.format(size))
-
-        return _mwm_2D(data, weights, size, c_method)
+        # Window moves along column rather than row, so if the window size 
+        # in dim 1 is larger than dim 0 this will run significantly faster
+        # on the transposed array
+        if size[0] < size[1]:
+            return _mwm_2D(data.T, weights.T, tuple(reversed(size)), c_method).T
+        else:
+            return _mwm_2D(data, weights, size, c_method)
     raise NotImplementedError('weighted_median() is only implemented for 1 and 2 dimensions, not {}'
                          .format(data.ndim))
 


### PR DESCRIPTION
Based on the way _mwm_2D moves over the array, the performance is significantly better if the 0th window size is larger than the 1st window size. 

Also, let `moving_weighted_median` accept any real numeric array