### PR TITLE
Add data directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # C extensions
 *.so
 
+# Data files
+caput/data/
+
 # Packages
 *.egg
 *.egg-info


### PR DESCRIPTION
Add directory `caput/data/` to gitignore. It is marked as untracked by git due to the following files, which are automatically downloaded by some routines in the `time` module:
```
caput/data/de421.bsp
caput/data/finals2000A.all
caput/data/Leap_Second.dat
```