### PR TITLE
Timstamp Alignment (1/4): Add `index_attrs` property to `BasicCont` to access attrs of index maps

### DIFF
--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -2205,10 +2205,22 @@ class BasicCont(MemDiskGroup):
         index_map : read only dictionary
             Entries are 1D arrays used to interpret the axes of datasets.
         """
-        out = {}
-        for name, value in self._data["index_map"].items():
-            out[name] = value[:]
-        return ro_dict(out)
+        return ro_dict({k: v[:] for k, v in self._data["index_map"].items()})
+
+    @property
+    def index_attrs(self):
+        """Exposes the attributes of each index_map entry.
+
+        Allows the user to implement custom behaviour associated with
+        the axis. Assignment to this dictionary does nothing but it does
+        allow attribute values to be changed.
+
+        Returns
+        -------
+        index_attrs : read-write dict
+            Attribute dicts for each index_map entry
+        """
+        return ro_dict({k: v.attrs for k, v in self._data["index_map"].items()})
 
     @property
     def reverse_map(self):

--- a/caput/tests/test_tod.py
+++ b/caput/tests/test_tod.py
@@ -74,6 +74,23 @@ class TestConcatenation(unittest.TestCase):
         )
         self.assertTrue(np.all(data["dset2"][:] == data.index_map["time"]))
 
+    def test_index_attr(self):
+        for d in self.todlist:
+            d.index_attrs["time"]["alignment"] = 1
+
+        data = tod.TOData.from_mult_files(self.todlist)
+
+        # Check that the alignment has been copied properly
+        self.assertTrue(data.index_attrs["time"]["alignment"] == 1)
+
+        # Check that the shift has been applied properly
+        self.assertTrue(
+            np.allclose(
+                data.index_map["time"][:],
+                data.time[:] - (abs(np.median(np.diff(data.time[:]))) / 2),
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/caput/tod.py
+++ b/caput/tod.py
@@ -396,6 +396,7 @@ def concatenate(
                 if convert_dataset_strings
                 else index_map,
             )
+        memh5.copyattrs(first_data.index_attrs[axis], out.index_attrs[axis])
 
     # Copy over the reverse maps.
     for axis, reverse_map in first_data.reverse_map.items():


### PR DESCRIPTION
This PR provides access to the `attrs` dict of each `index_map` container in a dataset, through a new property called `.index_attrs`. This is to allow us to set custom behaviour for any axis (such as alignment in time).

The proposed convention allows alignment to only be [-1, 0, 1], with 1 corresponding to a left-alignment index, -1 corresponding to a right-aligned index, and 0 a centred index. I'm open to changing this if an argument is made against it.

Related PRs:
- https://github.com/chime-experiment/ch_util/pull/52
- https://github.com/chime-experiment/ch_pipeline/pull/168
- https://github.com/radiocosmology/draco/pull/227