### PR TITLE
Provide `.copy` methods for `MemDataset` and `MemDiskGroup`

### DIFF
--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -68,6 +68,7 @@ from . import fileformats
 from . import mpiutil
 from . import mpiarray
 from . import misc
+from . import tools
 
 
 logger = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ class ro_dict(Mapping):
     def __eq__(self, other):
         if not isinstance(other, ro_dict):
             return False
-        return Mapping.__eq__(self, other) and self._dict == other._dict
+        return Mapping.__eq__(self, other) and tools.allequal(self._dict, other._dict)
 
 
 class _Storage(dict):
@@ -143,7 +144,7 @@ class _Storage(dict):
     def __eq__(self, other):
         if not isinstance(other, _Storage):
             return False
-        return dict.__eq__(self, other) and self._attrs == other._attrs
+        return dict.__eq__(self, other) and tools.allequal(self._attrs, other._attrs)
 
 
 class _StorageRoot(_Storage):
@@ -1102,7 +1103,9 @@ class MemDataset(_MemObjMixin):
     def __eq__(self, other):
         if not isinstance(other, MemDataset):
             return False
-        return _MemObjMixin.__eq__(self, other) and self._attrs == other._attrs
+        return _MemObjMixin.__eq__(self, other) and tools.allequal(
+            self._attrs, other._attrs
+        )
 
 
 class MemDatasetCommon(MemDataset):
@@ -1260,10 +1263,10 @@ class MemDatasetCommon(MemDataset):
             return False
         return (
             MemDataset.__eq__(self, other)
-            and self._data == other._data
-            and self._chunks == other._chunks
-            and self._compression == other._compression
-            and self._compression_opts == other._compression_opts
+            and tools.allequal(self._data, other._data)
+            and tools.allequal(self._chunks, other._chunks)
+            and tools.allequal(self._compression, other._compression)
+            and tools.allequal(self._compression_opts, other._compression_opts)
         )
 
 
@@ -1461,10 +1464,10 @@ class MemDatasetDistributed(MemDataset):
             return False
         return (
             MemDataset.__eq__(self, other)
-            and self._data == other._data
-            and self._chunks == other._chunks
-            and self._compression == other._compression
-            and self._compression_opts == other._compression_opts
+            and tools.allequal(self._data, other._data)
+            and tools.allequal(self._chunks, other._chunks)
+            and tools.allequal(self._compression, other._compression)
+            and tools.allequal(self._compression_opts, other._compression_opts)
         )
 
 

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -368,8 +368,7 @@ class _BaseGroup(_MemObjMixin, Mapping):
 
 
 class MemGroup(_BaseGroup):
-    """
-    In memory implementation of the :class:`h5py.Group`.
+    """In memory implementation of the :class:`h5py.Group`.
 
     This class doubles as the memory implementation of :class:`h5py.File`,
     object, since the distinction between a file and a group for in-memory data
@@ -1996,6 +1995,33 @@ class MemDiskGroup(_BaseGroup):
 
         if self.ondisk:
             self._data.flush()
+
+    def copy(self, shared: list = [], shallow: bool = False) -> MemDiskGroup:
+        """Return a deep copy of this class or subclass.
+
+        Parameters
+        ----------
+        shared
+            dataset names to share (i.e. don't deep copy)
+        shallow
+            True if this should be a shallow copy
+
+        Returns
+        -------
+        copy
+            Copy of this group
+        """
+        cls = self.__class__.__new__(self.__class__)
+        MemDiskGroup.__init__(cls, distributed=self.distributed, comm=self.comm)
+        deep_group_copy(
+            self._data, cls._data, deep_copy_dsets=not shallow, shared=shared
+        )
+
+        return cls
+
+    def __deepcopy__(self, memo, /) -> MemDiskGroup:
+        """Called when copy.deepcopy is called on this class"""
+        return self.copy()
 
     def save(
         self,

--- a/caput/tests/test_memh5.py
+++ b/caput/tests/test_memh5.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 from pytest_lazyfixture import lazy_fixture
 import zarr
+import copy
 
 from caput import memh5, fileformats
 
@@ -26,6 +27,34 @@ def test_ro_dict():
     with pytest.raises(TypeError):
         # pylint: disable=unsupported-assignment-operation
         a["b"] = 6
+
+
+# Unit test for MemDataset
+
+
+def test_dataset_copy():
+    # Check for string types
+    x = memh5.MemDatasetCommon(shape=(4, 5), dtype=np.float32)
+    x[:] = 0
+
+    # Check a deepcopy using .copy
+    y = x.copy()
+    assert x == y
+    y[:] = 1
+    # Check this this is in fact a deep copy
+    assert x != y
+
+    # This is a shallow copy
+    y = x.copy(shallow=True)
+    assert x == y
+    y[:] = 1
+    assert x == y
+
+    # Check a deepcopy using copy.deepcopy
+    y = copy.deepcopy(x)
+    assert x == y
+    y[:] = 2
+    assert x != y
 
 
 # Unit tests for MemGroup.

--- a/caput/tests/test_memh5_parallel.py
+++ b/caput/tests/test_memh5_parallel.py
@@ -5,6 +5,7 @@ from pytest_lazyfixture import lazy_fixture
 import numpy as np
 import h5py
 import zarr
+import copy
 
 from caput import fileformats, memh5, mpiarray, mpiutil
 
@@ -228,3 +229,31 @@ def test_redistribute():
     assert g["data"].distributed_axis == 0
     g.redistribute(1)
     assert g["data"].distributed_axis == 1
+
+
+# Unit test for MemDataset
+
+
+def test_dataset_copy():
+    # Check for string types
+    x = memh5.MemDatasetDistributed(shape=(4, 5), dtype=np.float32)
+    x[:] = 0
+
+    # Check a deepcopy using .copy
+    y = x.copy()
+    assert x == y
+    y[:] = 1
+    # Check this this is in fact a deep copy
+    assert x != y
+
+    # This is a shallow copy
+    y = x.copy(shallow=True)
+    assert x == y
+    y[:] = 1
+    assert x == y
+
+    # Check a deepcopy using copy.deepcopy
+    y = copy.deepcopy(x)
+    assert x == y
+    y[:] = 2
+    assert x != y

--- a/caput/tests/test_tools.py
+++ b/caput/tests/test_tools.py
@@ -1,0 +1,47 @@
+"""Unit tests for the tools module."""
+
+import numpy as np
+
+from caput import tools, mpiarray
+
+
+def test_allequal():
+    # Test some basic types
+    assert tools.allequal(1, 1)
+    assert tools.allequal("x", "x")
+    assert tools.allequal([1, 2, 3], [1, 2, 3])
+    assert tools.allequal({"a": 1}, {"a": 1})
+    assert tools.allequal({1, 2, 3}, {1, 2, 3})
+    assert tools.allequal((1, 2, 3), (1, 2, 3))
+
+    # Test numpy arrays and mpiarrays
+    assert tools.allequal(np.array([1, 2, 3]), np.array([1, 2, 3]))
+    assert tools.allequal(
+        mpiarray.MPIArray.wrap(np.array([1, 2, 3]), axis=0),
+        mpiarray.MPIArray.wrap(np.array([1, 2, 3]), axis=0),
+    )
+    assert not tools.allequal(
+        np.array([1, 2, 3]),
+        mpiarray.MPIArray.wrap(np.array([1, 2, 3]), axis=0),
+    )
+
+    # Test objects with numpy arrays in them
+    assert tools.allequal(
+        [np.array([1]), np.array([2])], [np.array([1]), np.array([2])]
+    )
+    assert tools.allequal({"a": np.array([1])}, {"a": np.array([1])})
+
+    # Test objects with different types
+    assert tools.allequal([1, 3.4, "a"], [1, 3.4, "a"])
+
+    # Test for items that are not equal
+    assert not tools.allequal(1, 3)
+    assert not tools.allequal(1, 1.1)
+    assert not tools.allequal([np.array([1])], [np.array([2])])
+    assert not tools.allequal(
+        np.array(["x"], dtype="U32"), np.array(["x"], dtype="S32")
+    )
+
+    # Test for lengths that are not equal
+    assert not tools.allequal([1], [1, 2])
+    assert not tools.allequal({"a": 1}, {"a": 1, "b": 2})

--- a/caput/tools.py
+++ b/caput/tools.py
@@ -66,3 +66,72 @@ def unique_ordered(x: Iterable) -> list:
     seen_add = seen.add
 
     return [i for i in x if not (i in seen or seen_add(i))]
+
+
+def allequal(obj1, obj2):
+    """Check if two objects are equal.
+
+    This comparison can check standard python types and numpy types,
+    even in the case where they are nested (ex: a dict with a numpy
+    array as a value).
+
+    Parameters
+    ----------
+    obj1 : scalar, list, tuple, dict, or np.ndarray
+    obj2 : scalar, list, tuple, dict, or np.ndarray
+    """
+    try:
+        _assert_equal(obj1, obj2)
+    except AssertionError:
+        return False
+    return True
+
+
+def _assert_equal(obj1, obj2):
+    """Assert two objects are equal.
+
+    This comparison can check standard python types and numpy types,
+    even in the case where they are nested (ex: a dict with a numpy
+    array as a value).
+
+    For more information:
+    https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_equal.html
+
+    Parameters
+    ----------
+    obj1 : scalar, list, tuple, dict, or np.ndarray
+    obj2 : scalar, list, tuple, dict, or np.ndarray
+    """
+    __tracebackhide__ = True
+    if isinstance(obj1, dict):
+        # Check that the dict-type objects are equivalent
+        if not isinstance(obj2, dict):
+            raise AssertionError(repr(type(obj2)))
+        _assert_equal(len(obj1), len(obj2))
+        # Check that each key:value pair are equal
+        for k in obj1.keys():
+            if k not in obj2:
+                raise AssertionError(repr(k))
+            _assert_equal(obj1[k], obj2[k])
+
+        return
+
+    if isinstance(obj1, (list, tuple)) and isinstance(obj2, (list, tuple)):
+        # Check that the sequence-type objects are equivalent
+        _assert_equal(len(obj1), len(obj2))
+        # Check that each item is the same
+        for k in range(len(obj1)):
+            _assert_equal(obj1[k], obj2[k])
+
+        return
+
+    # If both objects are np.ndarray subclasses, check that they
+    # have the same type
+    if isinstance(obj1, np.ndarray) and isinstance(obj2, np.ndarray):
+        assert type(obj1) == type(obj2)
+
+        obj1 = obj1.view(np.ndarray)
+        obj2 = obj2.view(np.ndarray)
+
+    # Check all other built-in types and numpy types are equal
+    np.testing.assert_equal(obj1, obj2)


### PR DESCRIPTION
This PR provides `.copy` methods for `MemDataset` and `MemDiskGroup` classes. 

`MemDataset.copy` can optionally do a deep or shallow copy (deep is default) and set the memory layout of the underlying data (if it is a numpy array). By default, this is the same layout as the dataset being copied. 

`MemDiskGroup.copy` deep copies all datasets by default and provides a `shared` argument. This is implemented via the `deep_group_copy` method, which is extended to optionally deep copy datasets (except those that are shared) and copy distributed arrays __only__ in the memory -> memory case. I made considerations based on discussion in #190. 

This PR also provides a a tool to check two objects which may contain numpy arrays for equality (ex: a list of arrays, dict with array arguments, etc...). For example, deep copying a list which contains a numpy array would result in an error when comparing the dicts, as the numpy arrays would not be the same object and would fall back on elementwise comparison. Since `list.__eq__` won't call `all()` on the numpy array after elementwise comparison, the comparison would fail. The same thing happens if the outer container is a dict.

Finally, the PR adds a check for matching `dtype` when comparing two `MemDatasets`. I'm undecided if this is a good idea or not.


NOTE: I've done a fair bit of testing and I think this is tentatively ready for review. I do still want to try to break it a bit more thoroughly. I've tagged a few possibly relevant people for review but it's fine if this waits for awhile