### PR TITLE
Use ruff for CI linting 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,16 +26,22 @@ jobs:
 
       - name: Install pip dependencies
         run: |
-          pip install pylint==2.7.0 pylint-ignore flake8 pytest black mpi4py pyinstrument psutil pytest-lazy-fixture
+          pip install ruff pytest black mpi4py pyinstrument psutil pytest-lazy-fixture
           pip install -r requirements.txt
           python setup.py develop
           pip install .[compression]
 
-      - name: Run flake8
-        run: flake8 --show-source --ignore=E501,E741,E203,W503,E266 caput
+      # - name: Run flake8
+      #   run: flake8 --show-source --ignore=E501,E741,E203,W503 caput
 
       - name: Check code with black
         run: black --check .
+
+      - name: Run ruff (flake8 and pydocstyle)
+        run: ruff check .
+
+      # - name: Run pydocstyle
+      #   run: pydocstyle --ignore=D105,D107,D203,D213,D400,D401,D402,D413,D416 caput
 
   run-tests:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install apt dependencies
         run: |
@@ -31,17 +31,11 @@ jobs:
           python setup.py develop
           pip install .[compression]
 
-      # - name: Run flake8
-      #   run: flake8 --show-source --ignore=E501,E741,E203,W503 caput
-
-      - name: Check code with black
-        run: black --check .
-
       - name: Run ruff (flake8 and pydocstyle)
         run: ruff check .
 
-      # - name: Run pydocstyle
-      #   run: pydocstyle --ignore=D105,D107,D203,D213,D400,D401,D402,D413,D416 caput
+      - name: Check code with black
+        run: black --check .
 
   run-tests:
 
@@ -89,10 +83,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install apt dependencies
       run: |

--- a/caput/__init__.py
+++ b/caput/__init__.py
@@ -1,9 +1,7 @@
-"""
-caput
+"""caput.
 
 Submodules
-==========
-
+----------
 .. autosummary::
     :toctree: _autosummary
 

--- a/caput/cache.py
+++ b/caput/cache.py
@@ -1,5 +1,4 @@
-"""Tools for caching expensive calculations.
-"""
+"""Tools for caching expensive calculations."""
 import weakref
 
 import numpy as np
@@ -36,7 +35,6 @@ class cached_property:
 
     Example
     -------
-
     >>> class A:
     ...     @cached_property
     ...     def v(self):

--- a/caput/config.py
+++ b/caput/config.py
@@ -1,13 +1,11 @@
-"""
-Configure class attributes using values from a dictionary.
+"""Configure class attributes using values from a dictionary.
 
 This module to defines strictly typed attributes of a class, that can be loaded
 from an input dictionary. This is particularly useful for loading a class from
 a YAML document.
 
 Examples
-========
-
+--------
 In this example we set up a class to store information about a person.
 
 >>> class Person(Reader):
@@ -84,7 +82,6 @@ class Property:
             If None (default), attempt to use the attribute name from the
             class.
         """
-
         self.proptype = (lambda x: x) if proptype is None else proptype
         self.default = default
         self.key = key
@@ -131,7 +128,6 @@ class Property:
         CaputConfigError
             If there was an error in the config dict.
         """
-
         self._set_propname(obj)
 
         if self.key is None:
@@ -173,8 +169,11 @@ class Reader:
         ----------
         config : dict
             Dictionary of configuration values.
+        *args : list
+            Variable length argument list
+        **kwargs : dict
+            Arbitrary keyword arguments.
         """
-
         c = cls(*args, **kwargs)
         c.read_config(config)
 
@@ -238,7 +237,7 @@ class Reader:
 
 
 def utc_time(default=None):
-    """A property for representing UTC as UNIX time.
+    """Property for representing UTC as UNIX time.
 
     Parameters
     ----------
@@ -266,7 +265,7 @@ def utc_time(default=None):
 
 
 def float_in_range(start, end, default=None):
-    """A property type that tests if its input is within the given range.
+    """Property type that tests if its input is within the given range.
 
     Parameters
     ----------
@@ -303,7 +302,7 @@ def float_in_range(start, end, default=None):
 
 
 def enum(options, default=None):
-    """A property type that accepts only a set of possible values.
+    """Property type that accepts only a set of possible values.
 
     Parameters
     ----------
@@ -346,7 +345,7 @@ def enum(options, default=None):
 
 
 def list_type(type_=None, length=None, maxlength=None, default=None):
-    """A property type that validates lists against required properties.
+    """Property type that validates lists against required properties.
 
     Parameters
     ----------
@@ -422,8 +421,7 @@ def list_type(type_=None, length=None, maxlength=None, default=None):
 
 
 def logging_config(default=None):
-    """
-    A Property type that validates the caput logging config.
+    """Property type that validates the caput logging config.
 
     Allows the type to be either a string (for backward compatibility) or a dict
     setting log levels per module.
@@ -484,7 +482,7 @@ def logging_config(default=None):
 
 
 def file_format(default: str | fileformats.FileFormat | None = None) -> Property:
-    """A property type that accepts only "zarr", or "hdf5".
+    """Property type that accepts only "zarr", or "hdf5".
 
     Returns the selected `caput.fileformat.FileFormat` subclass or `caput.fileformats.HDF5` if `value == default`.
 
@@ -551,14 +549,14 @@ class _line_dict(dict):
 
 
 class SafeLineLoader(SafeLoader):
-    """
-    YAML loader that tracks line numbers.
+    """YAML loader that tracks line numbers.
 
     Adds the line number information to every YAML block. This is useful for
     debugging and to describe linting errors.
     """
 
     def construct_mapping(self, node, deep=False):
+        """Construct the line mapping."""
         mapping = super().construct_mapping(node, deep=deep)
         mapping = _line_dict(mapping)
 
@@ -568,11 +566,10 @@ class SafeLineLoader(SafeLoader):
 
 
 class CaputConfigError(Exception):
-    """
-    There was an error in the configuration.
+    """There was an error in the configuration.
 
     Parameters
-    ==========
+    ----------
     message : str
         Message / description of error
     file_ : str

--- a/caput/fileformats.py
+++ b/caput/fileformats.py
@@ -35,8 +35,7 @@ class FileFormat:
 
     @staticmethod
     def open(*args, **vargs):
-        """
-        Open a file.
+        """Open a file.
 
         Not implemented in base class
         """
@@ -44,8 +43,7 @@ class FileFormat:
 
     @staticmethod
     def compression_kwargs(compression=None, compression_opts=None, compressor=None):
-        """
-        Sort compression arguments in a format expected by file format module.
+        """Sort compression arguments in a format expected by file format module.
 
         Parameters
         ----------
@@ -75,7 +73,7 @@ class HDF5(FileFormat):
 
     @staticmethod
     def compression_enabled():
-        """Disable compression and chunking due to bug: https://github.com/chime-experiment/Pipeline/issues/33"""
+        """Disable compression and chunking due to bug: https://github.com/chime-experiment/Pipeline/issues/33."""
         return False
 
     @staticmethod
@@ -165,8 +163,7 @@ class Zarr(FileFormat):
 
 
 class ZarrProcessSynchronizer:
-    """
-    A context manager for Zarr's ProcessSynchronizer that removes the lock files when done.
+    """A context manager for Zarr's ProcessSynchronizer that removes the lock files when done.
 
     If an MPI communicator is supplied, only rank 0 will attempt to remove files.
 
@@ -195,8 +192,7 @@ class ZarrProcessSynchronizer:
 
 
 def remove_file_or_dir(name: str):
-    """
-    Remove the file or directory with the given name.
+    """Remove the file or directory with the given name.
 
     Parameters
     ----------
@@ -216,8 +212,7 @@ def remove_file_or_dir(name: str):
 
 
 def guess_file_format(name, default=HDF5):
-    """
-    Guess the file format from the file name.
+    """Guess the file format from the file name.
 
     Parameters
     ----------
@@ -246,8 +241,7 @@ def guess_file_format(name, default=HDF5):
 
 
 def check_file_format(filename, file_format, data):
-    """
-    Compare file format with guess from filename and data. Return concluded format.
+    """Compare file format with guess from filename and data. Return concluded format.
 
     Parameters
     ----------
@@ -263,7 +257,6 @@ def check_file_format(filename, file_format, data):
     file_format : HDF5 or Zarr
         File format.
     """
-
     # check <file_format> value
     if file_format not in (None, HDF5, Zarr):
         raise ValueError(

--- a/caput/interferometry.py
+++ b/caput/interferometry.py
@@ -1,15 +1,13 @@
-"""
-Useful functions for radio interferometry.
-
+"""Useful functions for radio interferometry.
 
 Coordinates
-===========
+-----------
 - :py:meth:`sph_to_ground`
 - :py:meth:`ground_to_sph`
 - :py:meth:`project_distance`
 
 Interferometry
-==============
+--------------
 - :py:meth:`fringestop_phase`
 """
 
@@ -36,7 +34,6 @@ def sph_to_ground(ha, lat, dec):
     x, y, z : array_like
         The projected angular position in ground fixed XYZ coordinates.
     """
-
     x = -1 * np.cos(dec) * np.sin(ha)
     y = np.cos(lat) * np.sin(dec) - np.sin(lat) * np.cos(dec) * np.cos(ha)
     z = np.sin(lat) * np.sin(dec) + np.cos(lat) * np.cos(dec) * np.cos(ha)
@@ -63,7 +60,6 @@ def ground_to_sph(x, y, lat):
     ha, dec: array_like
         Hour Angle and declination in radians
     """
-
     z = np.sqrt(1 - x**2 - y**2)
 
     xe = z * np.cos(lat) - y * np.sin(lat)
@@ -99,7 +95,6 @@ def projected_distance(ha, lat, dec, x, y, z=0.0):
     dist : np.ndarray
         The projected distance. Has whatever units x, y, z did.
     """
-
     # We could use `sph_to_ground` here, but it's likely to be more memory
     # efficient to do this directly
     dist = x * (-1 * np.cos(dec) * np.sin(ha))
@@ -136,7 +131,6 @@ def fringestop_phase(ha, lat, dec, u, v, w=0.0):
         The phase required to *correct* the fringeing. Shape is
         given by the broadcast of the arguments together.
     """
-
     phase = -2.0j * np.pi * projected_distance(ha, lat, dec, u, v, w)
 
     return np.exp(phase, out=phase)

--- a/caput/misc.py
+++ b/caput/misc.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 def vectorize(**base_kwargs):
-    """An improved vectorization decorator.
+    """Improved vectorization decorator.
 
     Unlike the :class:`np.vectorize` decorator this version works on methods in
     addition to functions. It also gives an actual scalar value back for any
@@ -15,7 +15,7 @@ def vectorize(**base_kwargs):
 
     Parameters
     ----------
-    **kwargs
+    **base_kwargs
         Any keyword arguments accepted by :class:`np.vectorize`
 
     Returns
@@ -256,7 +256,6 @@ class lock_file:
 
     Examples
     --------
-
     >>> from . import memh5
     >>> container = memh5.BasicCont()
     >>> with lock_file('file_to_create.h5') as fname:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1,9 +1,7 @@
-"""
-An array class for containing MPI distributed array.
+"""An array class for containing MPI distributed array.
 
 Examples
-========
-
+--------
 This example performs a transfrom from time-freq to lag-m space. This involves
 Fourier transforming each of these two axes of the distributed array::
 
@@ -470,8 +468,7 @@ class MPIArray(np.ndarray):
 
     @property
     def global_shape(self):
-        """
-        Global array shape.
+        """Global array shape.
 
         Returns
         -------
@@ -481,19 +478,18 @@ class MPIArray(np.ndarray):
 
     @global_shape.setter
     def global_shape(self, var):
-        """
-        Set global array shape.
+        """Set global array shape.
 
         Parameters
         ----------
         var : tuple
+            New global shape
         """
         self._global_shape = var
 
     @property
     def axis(self):
-        """
-        Axis we are distributed over.
+        """Axis we are distributed over.
 
         Returns
         -------
@@ -503,19 +499,20 @@ class MPIArray(np.ndarray):
 
     @axis.setter
     def axis(self, var):
-        """
-        Set axis we are distributed over.
+        """Set axis we are distributed over.
+
+        This does not redistribute the array.
 
         Parameters
         ----------
         var : int
+            New distributed axis
         """
         self._axis = var
 
     @property
     def local_shape(self):
-        """
-        Shape of local section.
+        """Shape of local section.
 
         Returns
         -------
@@ -525,19 +522,18 @@ class MPIArray(np.ndarray):
 
     @local_shape.setter
     def local_shape(self, var):
-        """
-        Set shape of local section.
+        """Set shape of local section.
 
         Parameters
         ----------
         var : tuple
+            New local shape
         """
         self._local_shape = var
 
     @property
     def local_offset(self):
-        """
-        Offset into global array.
+        """Offset into global array.
 
         This is equivalent to the global-index of
         the [0, 0, ...] element of the local section.
@@ -550,19 +546,18 @@ class MPIArray(np.ndarray):
 
     @local_offset.setter
     def local_offset(self, var):
-        """
-        Set offset into global array.
+        """Set offset into global array.
 
         Parameters
         ----------
         var : tuple
+            New local offset
         """
         self._local_offset = var
 
     @property
     def local_array(self):
-        """
-        The view of the local numpy array.
+        """The view of the local numpy array.
 
         Returns
         -------
@@ -572,15 +567,12 @@ class MPIArray(np.ndarray):
 
     @property
     def local_bounds(self) -> slice:
-        """
-        Global bounds of the local array along the
-        distributed axis.
+        """Global bounds of the local array along the distributed axis.
 
         Returns
         -------
         local_bounds
         """
-
         return slice(
             self.local_offset[self.axis],
             self.local_offset[self.axis] + self.local_shape[self.axis],
@@ -588,8 +580,7 @@ class MPIArray(np.ndarray):
 
     @property
     def comm(self):
-        """
-        The communicator over which the array is distributed.
+        """The communicator over which the array is distributed.
 
         Returns
         -------
@@ -599,16 +590,17 @@ class MPIArray(np.ndarray):
 
     @comm.setter
     def comm(self, var):
-        """
-        Set the communicator over which the array is distributed.
+        """Set the communicator over which the array is distributed.
 
         Parameters
         ----------
         var : MPI.Comm
+            New communicator
         """
         self._comm = var
 
     def __new__(cls, global_shape, axis=0, comm=None, *args, **kwargs):
+        """Make a new MPIArray."""
         # if mpiutil.world is None:
         #     raise RuntimeError('There is no mpi4py installation. Aborting.')
 
@@ -639,8 +631,7 @@ class MPIArray(np.ndarray):
 
     @property
     def global_slice(self):
-        """
-        Return an objects that presents a view of the array with global slicing.
+        """Return an objects that presents a view of the array with global slicing.
 
         Returns
         -------
@@ -658,7 +649,6 @@ class MPIArray(np.ndarray):
         comm: "MPI.IntraComm",
     ) -> "MPIArray":
         """Create an MPIArray view of a numpy array."""
-
         # Set shape and offset
         lshape = array.shape
         global_shape = list(lshape)
@@ -700,7 +690,6 @@ class MPIArray(np.ndarray):
         dist_array : MPIArray
             An MPIArray view of the input.
         """
-
         # from mpi4py import MPI
 
         if comm is None:
@@ -1056,7 +1045,10 @@ class MPIArray(np.ndarray):
             File to write dataset into.
         dataset : string
             Name of dataset to write into. Should not exist.
+        create : bool, optional
+            True if a new file should be created (if needed)
         chunks
+            Chunking arguments
         compression : str or int
             Name or identifier of HDF5 compression filter.
         compression_opts
@@ -1152,7 +1144,10 @@ class MPIArray(np.ndarray):
             File to write dataset into.
         dataset : string
             Name of dataset to write into. Should not exist.
+        create : bool, optional
+            True if a new file should be created (if needed)
         chunks
+            Chunking arguments
         compression : str or int
             Name or identifier of HDF5 compression filter.
         compression_opts
@@ -1246,12 +1241,17 @@ class MPIArray(np.ndarray):
             File to write dataset into.
         dataset : string
             Name of dataset to write into. Should not exist.
+        create : bool, optional
+            True if a new file should be created (if needed)
         chunks
+            Chunking arguments
         compression : str or int
             Name or identifier of HDF5 compression filter.
         compression_opts
             See HDF5 documentation for compression filters.
             Compression options for the dataset.
+        file_format : :class:`fileforats.FileFormat`
+            File format interface class
         """
         if chunks is None and hasattr(self, "chunks"):
             logger.error(f"getting chunking opts from mpiarray: {self.chunks}")
@@ -1299,7 +1299,6 @@ class MPIArray(np.ndarray):
         array : MPIArray
             Transposed MPIArray as a view of the original data.
         """
-
         tdata = np.ndarray.transpose(self, *axes)
 
         if len(axes) == 1 and isinstance(axes[0], (tuple, list)):
@@ -1332,7 +1331,6 @@ class MPIArray(np.ndarray):
         array : MPIArray
             Reshaped MPIArray as a view of the original data.
         """
-
         if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
             shape = tuple(shape[0])
 
@@ -1391,7 +1389,6 @@ class MPIArray(np.ndarray):
         arr : np.ndarray, or None
             The full global array on the specified rank.
         """
-
         if self.comm.rank == rank:
             arr = np.ndarray(self.global_shape, dtype=self.dtype)
         else:
@@ -1485,8 +1482,10 @@ class MPIArray(np.ndarray):
         )
 
     def ravel(self, *args, **kwargs):
-        """This method is explicitly not implemented and will
-        return a NotImplementedError.
+        """Method is explicitly not implemented.
+
+        This method would return a flattened view of the entire
+        array, which is not supported across the distributed axis.
 
         Raises
         ------
@@ -1509,9 +1508,10 @@ class MPIArray(np.ndarray):
             File to write dataset into.
         dataset : string
             Name of dataset to write into.
+        create : bool, optional
+            True if a new file should be created (if needed)
         """
-
-        ## Naive non-parallel implementation to start
+        # Naive non-parallel implementation to start
 
         import h5py
 
@@ -1682,7 +1682,6 @@ class MPIArray(np.ndarray):
             dictionary containing the optional input arguments of the ufunc.  Important
             kwargs considered here are 'out' and 'axis'.
         """
-
         # Each ufunc application method must have a corresponding function that both
         # validates the inputs and arguments are appropriate (same distributed axis
         # etc.), and infers and returns the parameters of the output distributed axis
@@ -1869,8 +1868,7 @@ class MPIArray(np.ndarray):
     # pylint: enable=too-many-branches
 
     def __array_finalize__(self, obj):
-        """
-        Finalizes the creation of the MPIArray, when viewed.
+        """Finalizes the creation of the MPIArray, when viewed.
 
         Note: If you wish to create an MPIArray from an ndarray, please use wrap().
         Do not use ndarray.view(MPIArray).
@@ -1943,7 +1941,6 @@ def zeros(*args, **kwargs) -> MPIArray:
     MPIArray
         The filled MPIArray.
     """
-
     arr = MPIArray(*args, **kwargs)
     arr[:] = 0
 
@@ -1963,7 +1960,6 @@ def ones(*args, **kwargs) -> MPIArray:
     MPIArray
         The filled MPIArray.
     """
-
     arr = MPIArray(*args, **kwargs)
     arr[:] = 1
 
@@ -1971,8 +1967,7 @@ def ones(*args, **kwargs) -> MPIArray:
 
 
 def _partition_sel(sel, split_axis, n, slice_):
-    """
-    Re-slice a selection along a new axis.
+    """Re-slice a selection along a new axis.
 
     Take a selection (a tuple of slices) and re-slice along the split_axis (which has
     length n).
@@ -1985,7 +1980,8 @@ def _partition_sel(sel, split_axis, n, slice_):
         New split axis
     n : int
         Length of split axis
-    slice_
+    slice_ : List[slice]
+        New slice along new axis
 
     Returns
     -------
@@ -2217,7 +2213,6 @@ def sanitize_slice(
     IndexError
         For incompatible slices, such as too many axes.
     """
-
     orig_sl = sl
 
     # Add an Ellipsis at the very end if it isn't present elsewhere

--- a/caput/pfb.py
+++ b/caput/pfb.py
@@ -56,7 +56,6 @@ def sinc_hann(ntap, lblock):
     -------
     window : np.ndarray[ntap * lblock]
     """
-
     return sinc_window(ntap, lblock) * np.hanning(ntap * lblock)
 
 
@@ -74,7 +73,6 @@ def sinc_hamming(ntap, lblock):
     -------
     window : np.ndarray[ntap * lblock]
     """
-
     return sinc_window(ntap, lblock) * np.hamming(ntap * lblock)
 
 
@@ -117,7 +115,6 @@ class PFB:
         pfb : np.ndarray[:, lblock // 2]
             Array of PFB frequencies.
         """
-
         # Number of blocks
         nblock = timestream.size // self.lblock - (self.ntap - 1)
 
@@ -143,7 +140,7 @@ class PFB:
     _decorr_interp = None
 
     def decorrelation_ratio(self, delay):
-        """Calculates the decorrelation caused by a relative relay of two timestreams.
+        """Calculate the decorrelation caused by a relative relay of two timestreams.
 
         This is caused by the fact that the PFB is generated from a finite
         time window of data.
@@ -159,7 +156,6 @@ class PFB:
         decorrelation : array_like
             The decorrelation ratio.
         """
-
         if self._decorr_interp is None:
             N = self.ntap * self.lblock
 

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -1,5 +1,4 @@
-"""
-Data Analysis and Simulation Pipeline.
+"""Data Analysis and Simulation Pipeline.
 
 A data analysis pipeline is completely specified by a YAML file that specifies
 both what tasks are to be run and the parameters that go to those tasks.
@@ -28,8 +27,7 @@ Task base classes
 
 
 Examples
-========
-
+--------
 Basic Tasks
 -----------
 
@@ -391,7 +389,7 @@ class PipelineRuntimeError(Exception):
 
 
 class PipelineStopIteration(Exception):
-    """This stops the iteration of `next()` in pipeline tasks.
+    """Stop the iteration of `next()` in pipeline tasks.
 
     Pipeline tasks should raise this excetions in the `next()` method to stop
     the iteration of the task and to proceed to `finish()`.
@@ -422,8 +420,7 @@ class _PipelineFinished(Exception):
 
 
 def _get_versions(modules):
-    """
-    Get the versions of a list of python modules.
+    """Get the versions of a list of python modules.
 
     Parameters
     ----------
@@ -527,7 +524,6 @@ class Manager(config.Reader):
         -------
         self: Pipeline object
         """
-
         try:
             with open(file_name) as f:
                 yaml_doc = f.read()
@@ -585,8 +581,7 @@ class Manager(config.Reader):
         return self
 
     def _setup_logging(self, lint=False):
-        """
-        Set up logging based on the config.
+        """Set up logging based on the config.
 
         Parameters
         ----------
@@ -617,7 +612,6 @@ class Manager(config.Reader):
             If a task stage returns the wrong number of outputs.
 
         """
-
         # Run the pipeline.
         while self.tasks:
             for task in list(self.tasks):  # Copy list so we can alter it.
@@ -660,8 +654,7 @@ class Manager(config.Reader):
 
     @staticmethod
     def _check_task_output(out, task):
-        """
-        Check if task stage's output is as expected.
+        """Check if task stage's output is as expected.
 
         Returns
         -------
@@ -695,7 +688,6 @@ class Manager(config.Reader):
 
     def _setup_tasks(self):
         """Create and setup all tasks from the task list."""
-
         all_out_values = {t.get("out", None) for t in self.task_specs}
 
         # Setup all tasks in the task listk
@@ -736,7 +728,6 @@ class Manager(config.Reader):
 
     def _setup_task(self, task_spec):
         """Set up a pipeline task from the spec given in the tasks list."""
-
         # Check that only the expected keys are in the task spec.
         for key in task_spec.keys():
             if key not in ["type", "params", "requires", "in", "out"]:
@@ -865,9 +856,7 @@ class TaskBase(config.Reader):
         May be overridden with no arguments.  Will be called after any
         `config.Property` attributes are set and after 'input' and 'requires'
         keys are set up.
-
         """
-
         pass
 
     def setup(self, requires=None):
@@ -879,13 +868,12 @@ class TaskBase(config.Reader):
 
         Any return values will be treated as pipeline data-products as
         specified by the `out` keys in the pipeline setup.
-
         """
-
         pass
 
     def validate(self):
         """Validate the task after instantiation."""
+        pass
 
     def next(self, input=None):
         """Iterative analysis stage of pipeline task.
@@ -900,9 +888,7 @@ class TaskBase(config.Reader):
 
         Any return values will be treated as pipeline data-products as
         specified by the `out` keys in the pipeline setup.
-
         """
-
         raise PipelineStopIteration()
 
     def finish(self):
@@ -912,9 +898,7 @@ class TaskBase(config.Reader):
 
         Any return values will be treated as pipeline data-products as
         specified by the `out` keys in the pipeline setup.
-
         """
-
         pass
 
     @property
@@ -931,9 +915,7 @@ class TaskBase(config.Reader):
         and `finish()` must always be parallelized internally.
 
         Usage of this has not implemented.
-
         """
-
         return False
 
     @property
@@ -941,9 +923,7 @@ class TaskBase(config.Reader):
         """Override to return `True` if caching results is implemented.
 
         No caching infrastructure has yet been implemented.
-
         """
-
         return False
 
     # Pipeline Infrastructure
@@ -959,7 +939,6 @@ class TaskBase(config.Reader):
 
     def _setup_keys(self, in_=None, out=None, requires=None):
         """Setup the 'requires', 'in' and 'out' keys for this task."""
-
         # Put pipeline in state such that `setup` is the next stage called.
         self._pipeline_advance_state()
         # Parse the task spec.
@@ -1024,9 +1003,7 @@ class TaskBase(config.Reader):
 
         Also performs some clean up tasks and checks associated with changing
         stages.
-
         """
-
         if not hasattr(self, "_pipeline_state"):
             self._pipeline_state = "setup"
         elif self._pipeline_state == "setup":
@@ -1059,9 +1036,7 @@ class TaskBase(config.Reader):
         Execute `setup()`, `next()`, `finish()` or raise `PipelineFinished`
         depending on the state of the task.  Advance the state to the next
         stage if applicable.
-
         """
-
         if self._pipeline_state == "setup":
             # Check if we have all the required input data.
             for req in self._requires:
@@ -1108,9 +1083,7 @@ class TaskBase(config.Reader):
         as inputs to `setup()` ('requires') and `next()` ('in').  If there is a
         match, store the corresponding data product to be used in the next
         invocation of these methods.
-
         """
-
         n_keys = len(keys)
         for ii in range(n_keys):
             key = keys[ii]
@@ -1128,7 +1101,7 @@ class TaskBase(config.Reader):
                             "`setup()` already run."
                         )
                         raise PipelineRuntimeError(msg)
-                    if not self._requires[jj] is None:
+                    if self._requires[jj] is not None:
                         msg = "'requires' data product set more than once."
                         raise PipelineRuntimeError(msg)
                     else:
@@ -1152,7 +1125,7 @@ class TaskBase(config.Reader):
 
 
 class _OneAndOne(TaskBase):
-    """Base class for tasks that have (at most) one input and one output
+    """Base class for tasks that have (at most) one input and one output.
 
     This is not a user base class and simply holds code that is common to
     `SingleBase` and `IterBase`.
@@ -1173,13 +1146,12 @@ class _OneAndOne(TaskBase):
 
     def process(self, input):
         """Override this method with your data processing task."""
-
         output = input
+
         return output
 
     def validate(self):
-        """
-        Validate the task after instantiation.
+        """Validate the task after instantiation.
 
         May be overriden to add any special task validation before the task is run.
         This is called by the :py:class:`Manager` after it's added to the pipeline and has special attributes like
@@ -1235,7 +1207,6 @@ class _OneAndOne(TaskBase):
 
     def read_process_write(self, input, input_filename, output_filename):
         """Reads input, executes any processing and writes output."""
-
         # Read input if needed.
         if input is None and not self._no_input:
             if input_filename is None:
@@ -1275,27 +1246,22 @@ class _OneAndOne(TaskBase):
 
     def read_input(self, filename):
         """Override to implement reading inputs from disk."""
-
         raise NotImplementedError()
 
     def cast_input(self, input):
         """Override to support accepting pipeline inputs of variouse types."""
-
         return input
 
     def read_output(self, filename):
         """Override to implement reading outputs from disk.
 
         Used for result cacheing.
-
         """
-
         raise NotImplementedError()
 
     @staticmethod
     def write_output(filename, output, file_format=None, **kwargs):
         """Override to implement reading inputs from disk."""
-
         raise NotImplementedError()
 
 
@@ -1344,7 +1310,6 @@ class SingleBase(_OneAndOne):
 
     def next(self, input=None):
         """Should not need to override."""
-
         # This should only be called once.
         try:
             if self.done:
@@ -1408,7 +1373,6 @@ class IterBase(_OneAndOne):
 
     def next(self, input=None):
         """Should not need to override."""
-
         # Sort out filenames.
         if self.iteration >= len(self.file_middles):
             if not self.input_root == "None":
@@ -1441,7 +1405,6 @@ class H5IOMixin:
 
     Provides the methods `read_input`, `read_output` and `write_output` for
     hdf5 data.
-
     """
 
     # TODO, implement reading on disk (i.e. no copy to memory).
@@ -1450,7 +1413,6 @@ class H5IOMixin:
     @staticmethod
     def read_input(filename):
         """Method for reading hdf5 input."""
-
         from caput import memh5
 
         return memh5.MemGroup.from_hdf5(filename, mode="r")
@@ -1458,7 +1420,6 @@ class H5IOMixin:
     @staticmethod
     def read_output(filename):
         """Method for reading hdf5 output (from caches)."""
-
         # Replicate code from read_input in case read_input is overridden.
         from caput import memh5
 
@@ -1466,8 +1427,7 @@ class H5IOMixin:
 
     @staticmethod
     def write_output(filename, output, file_format=None, **kwargs):
-        """
-        Method for writing hdf5/zarr output.
+        """Method for writing hdf5/zarr output.
 
         Parameters
         ----------
@@ -1479,8 +1439,9 @@ class H5IOMixin:
         file_format : fileformats.Zarr, fileformats.HDF5 or None
             File format to use. If this is not specified, the file format is guessed based on the type of
             `output` or the `filename`. If guessing is not successful, HDF5 is used.
+        **kwargs : dict
+            Arbitrary keyword arguments.
         """
-
         from caput import memh5
         import h5py
 
@@ -1553,7 +1514,6 @@ class BasicContMixin:
 
     Provides the methods `read_input`, `read_output` and `write_output` for
     BasicCont data which gets written to HDF5 files.
-
     """
 
     # TODO, implement reading on disk (i.e. no copy to memory).
@@ -1565,7 +1525,6 @@ class BasicContMixin:
 
     def read_input(self, filename):
         """Method for reading hdf5 input."""
-
         from caput import memh5
 
         return memh5.BasicCont.from_file(
@@ -1574,7 +1533,6 @@ class BasicContMixin:
 
     def read_output(self, filename):
         """Method for reading hdf5 output (from caches)."""
-
         # Replicate code from read_input in case read_input is overridden.
         from caput import memh5
 
@@ -1584,8 +1542,7 @@ class BasicContMixin:
 
     @staticmethod
     def write_output(filename, output, file_format=None, **kwargs):
-        """
-        Method for writing output to disk.
+        """Method for writing output to disk.
 
         Parameters
         ----------
@@ -1595,12 +1552,9 @@ class BasicContMixin:
             Data to be written.
         file_format : `fileformats.FileFormat`
             File format to use. Default `fileformats.HDF5`.
-
-        Returns
-        -------
-
+        **kwargs : dict
+            Arbitrary keyword arguments.
         """
-
         from caput import memh5
 
         file_format = fileformats.check_file_format(filename, file_format, output)
@@ -1628,7 +1582,6 @@ class SingleH5Base(H5IOMixin, SingleBase):
     """Base class for tasks with hdf5 input and output.
 
     Inherits from :class:`H5IOMixin` and :class:`SingleBase`.
-
     """
 
     pass
@@ -1638,7 +1591,6 @@ class IterH5Base(H5IOMixin, IterBase):
     """Base class for iterating over hdf5 input and output.
 
     Inherits from :class:`H5IOMixin` and :class:`IterBase`.
-
     """
 
     pass
@@ -1658,7 +1610,6 @@ class Input(TaskBase):
 
     def next(self):
         """Pop and return the first element of inputs."""
-
         if self._iter is None:
             self._iter = iter(self.inputs)
 
@@ -1690,7 +1641,6 @@ class Output(TaskBase):
 
     def next(self, in_):
         """Pop and return the first element of inputs."""
-
         if self.callback:
             in_ = self.callback(in_)
 
@@ -1708,9 +1658,7 @@ def _format_product_keys(keys):
     are keys representing data products.  This function gets that key from the
     task's entry of the task list, defaults to zero, and ensures it's formated
     as a sequence of strings.
-
     """
-
     if keys is None:
         return []
 

--- a/caput/profile.py
+++ b/caput/profile.py
@@ -293,8 +293,7 @@ class PSUtilProfiler(psutil.Process):
         self.stop()
 
     def start(self):
-        """
-        Start profiling.
+        """Start profiling.
 
         Results generated when `stop` is called are based on this start time.
 
@@ -312,8 +311,7 @@ class PSUtilProfiler(psutil.Process):
                 self._start_disk_io = self.io_counters()
 
     def stop(self):
-        """
-        Stop profiler. Dump results to csv file and/or log and/or set results on self.usage.
+        """Stop profiler. Dump results to csv file and/or log and/or set results on self.usage.
 
         `start` must be called first.
 

--- a/caput/scripts/__init__.py
+++ b/caput/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tools for running caput piplines."""

--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -1,3 +1,5 @@
+"""CLI interface to run caput pipelines."""
+
 import itertools
 import os
 import sys
@@ -286,7 +288,7 @@ def queue(
     psutil=False,
     overwrite="never",
 ):
-    """Queue a pipeline on a cluster from the given CONFIGFILE.
+    r"""Queue a pipeline on a cluster from the given CONFIGFILE.
 
     This queues the job, using parameters from the `cluster` section of the
     submitted YAML file.
@@ -339,7 +341,6 @@ def queue(
         may be slow, if the temporary and final directories are not on the
         same filesystem.
     """
-
     import shutil
     import yaml
 
@@ -361,8 +362,8 @@ def queue(
     with open(configfile, "r") as f:
         yconf = yaml.safe_load(f)
 
-    ## Global configuration
-    ## Create output directory and copy over params file.
+    # Global configuration
+    # Create output directory and copy over params file.
     if "cluster" not in yconf:
         raise ValueError('Configuration file must have an "cluster" section.')
 
@@ -568,12 +569,12 @@ fi
 
 
 def expandpath(path):
-    """Expand any variables, user directories in path"""
+    """Expand any variables, user directories in path."""
     return Path(os.path.expandvars(path)).expanduser().resolve()
 
 
 def fixpath(path):
-    """Turn path to an absolute path"""
+    """Turn path to an absolute path."""
     return Path(path).resolve()
 
 

--- a/caput/tests/__init__.py
+++ b/caput/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `caput` module."""

--- a/caput/tests/conftest.py
+++ b/caput/tests/conftest.py
@@ -35,15 +35,18 @@ class PrintEggs(TaskBase):
         super().__init__(*args, **kwargs)
 
     def setup(self, requires=None):
+        """Run setup."""
         print("Setting up PrintEggs.")
 
     def next(self, _input=None):
+        """Run next."""
         if self.i >= len(self.eggs):
             raise PipelineStopIteration()
         print("Spam and %s eggs." % self.eggs[self.i])
         self.i += 1
 
     def finish(self):
+        """Run finish."""
         print("Finished PrintEggs.")
 
 
@@ -57,9 +60,11 @@ class GetEggs(TaskBase):
         super().__init__(*args, **kwargs)
 
     def setup(self, requires=None):
+        """Run setup."""
         print("Setting up GetEggs.")
 
     def next(self, _input=None):
+        """Run next."""
         if self.i >= len(self.eggs):
             raise PipelineStopIteration()
         egg = self.eggs[self.i]
@@ -67,6 +72,7 @@ class GetEggs(TaskBase):
         return egg
 
     def finish(self):
+        """Run finish."""
         print("Finished GetEggs.")
 
 
@@ -76,21 +82,27 @@ class CookEggs(IterBase):
     style = config.Property(proptype=str)
 
     def setup(self, requires=None):
+        """Run setup."""
         print("Setting up CookEggs.")
 
     def process(self, _input):
+        """Run process."""
         print("Cooking %s %s eggs." % (self.style, input))
 
     def finish(self):
+        """Run finish."""
         print("Finished CookEggs.")
 
     def read_input(self, filename):
+        """Run read input not implemented."""
         raise NotImplementedError()
 
     def read_output(self, filename):
+        """Run read output not implemented."""
         raise NotImplementedError()
 
     def write_output(self, filename, output, file_format=None, **kwargs):
+        """Run write output not implemented."""
         raise NotImplementedError()
 
 
@@ -114,8 +126,7 @@ cook_params:
 
 
 def run_pipeline(parameters=None, configstr=eggs_pipeline_conf):
-    """
-    Run `caput.scripts.runner run` with given parameters and config.
+    """Run `caput.scripts.runner run` with given parameters and config.
 
     Parameters
     ----------
@@ -128,9 +139,7 @@ def run_pipeline(parameters=None, configstr=eggs_pipeline_conf):
     -------
     result : `click.testing.Result`
         Holds the captured result. Try accessing e.g. `result.exit_code`, `result.output`.
-
     """
-
     with tempfile.NamedTemporaryFile("w+") as configfile:
         configfile.write(configstr)
         configfile.flush()

--- a/caput/tests/test_config.py
+++ b/caput/tests/test_config.py
@@ -6,7 +6,7 @@ import yaml
 from caput import config
 
 
-### Test classes
+# Test classes
 class Person(config.Reader):
     name = config.Property(default="Bill", proptype=str)
     age = config.Property(default=26, proptype=float, key="ageinyears")
@@ -27,11 +27,11 @@ class DictTypeTests(config.Reader):
     dict_config = config.Property(proptype=dict)
 
 
-### Test data dict
+# Test data dict
 testdict = {"name": "Richard", "ageinyears": 40, "petname": "Sooty"}
 
 
-### Tests
+# Tests
 def test_default_params():
     person1 = Person()
 

--- a/caput/tests/test_mpiarray.py
+++ b/caput/tests/test_mpiarray.py
@@ -774,7 +774,7 @@ def test_ufunc_misc():
     dist_array1.local_array[:] = 1.0
     dist_array2.local_array[:] = 1.0
 
-    ## Check that unsupported operations types fail
+    # Check that unsupported operations types fail
     # Check that an outer call fails
     with pytest.raises(mpiarray.UnsupportedOperation):
         np.multiply.outer(dist_array1, dist_array2)

--- a/caput/time.py
+++ b/caput/time.py
@@ -1,5 +1,4 @@
-r"""
-Routines for calculation and of solar and sidereal times.
+r"""Routines for calculation and of solar and sidereal times.
 
 This module can:
 
@@ -267,7 +266,6 @@ class Observer:
         -------
         lsa : float
         """
-
         era = unix_to_era(time)
 
         lsa = (era + self.longitude) % 360.0
@@ -278,8 +276,7 @@ class Observer:
 
     @listize()
     def lsa_to_unix(self, lsa, time0):
-        """Convert a Local Stellar Angle (LSA) on a given
-        day to a UNIX time.
+        """Convert a Local Stellar Angle (LSA) on a given day to a UNIX time.
 
         Parameters
         ----------
@@ -294,7 +291,6 @@ class Observer:
         time : scalar or np.ndarray
             Corresponding UNIX time.
         """
-
         era = (lsa - self.longitude) % 360.0
 
         return era_to_unix(era, time0)
@@ -325,7 +321,6 @@ class Observer:
         -------
         lsd : float or array of
         """
-
         # Get fractional part from LRA
         frac_part = self.unix_to_lsa(time) / 360.0
 
@@ -348,13 +343,12 @@ class Observer:
         Parameters
         ----------
         lsd : float or array of
-
+            Local Stellar Day to convert to unix
         Returns
         -------
         time :  float or array of
             UNIX time
         """
-
         # Find the approximate UNIX time
         approx_unix = self.lsd_zero() + lsd * 3600 * 24 * SIDEREAL_S
 
@@ -381,7 +375,6 @@ class Observer:
         lst : float or array of
             The apparent LST in degrees.
         """
-
         st = unix_to_skyfield_time(unix)
 
         return (st.gast * 15.0 + self.longitude) % 360.0
@@ -408,7 +401,6 @@ class Observer:
 
         Notes
         -----
-
         It is not clear that this calculation includes nutation and stellar
         aberration.  See the discussion
         `on stackoverflow <http://stackoverflow.com/questions/11970713>`_.
@@ -422,7 +414,6 @@ class Observer:
         PyEphem uses all geocentric latitudes, which I don't think affects
         this calculation.
         """
-
         # Initialize Skyfield location object.
         obs = self.skyfield_obs()
 
@@ -477,7 +468,6 @@ class Observer:
         dec : np.ndarray
             Only returned if `return_dec` is set. Declination of source at transit.
         """
-
         if isinstance(source, float):
             source = skyfield_star_from_ra_dec(source, 0.0)
 
@@ -674,7 +664,6 @@ def unix_to_skyfield_time(unix_time):
     -------
     time : :class:`skyfield.timelib.Time`
     """
-
     ts = skyfield_wrapper.timescale
 
     days, seconds = divmod(unix_time, 24 * 3600.0)
@@ -727,7 +716,6 @@ def unix_to_era(unix_time):
     era : float or array of
         The Earth Rotation Angle in degrees.
     """
-
     from skyfield import earthlib
 
     t = unix_to_skyfield_time(unix_time)
@@ -760,7 +748,6 @@ def era_to_unix(era, time0):
     unix_time : float or array of.
         Unix/POSIX time.
     """
-
     era0 = unix_to_era(time0)
 
     diff_era_deg = (era - era0) % 360.0  # Convert from degrees in seconds (time)
@@ -788,15 +775,14 @@ def unix_to_datetime(unix_time):
         Unix/POSIX time.
 
     Returns
-    --------
+    -------
     dt : :class:`datetime.datetime`
+        datetime object from the provided time
 
     See Also
     --------
     :func:`datetime_to_unix`
-
     """
-
     dt = datetime.utcfromtimestamp(unix_time)
 
     return naive_datetime_to_utc(dt)
@@ -811,6 +797,7 @@ def datetime_to_unix(dt):
     Parameters
     ----------
     dt : :class:`datetime.datetime`
+        datetime object to convert to unix
 
     Returns
     -------
@@ -821,7 +808,6 @@ def datetime_to_unix(dt):
     --------
     :func:`unix_to_datetime`
     :meth:`datetime.datetime.utcfromtimestamp`
-
     """
     # Noting that this operation is ignorant of leap seconds.
     dt = naive_datetime_to_utc(dt)
@@ -839,6 +825,7 @@ def datetime_to_timestr(dt):
     Parameters
     ----------
     dt : :class:`datetime.datetime`
+        datetime object to convert to timestring
 
     Returns
     -------
@@ -848,9 +835,7 @@ def datetime_to_timestr(dt):
     See Also
     --------
     :func:`timestr_to_datetime`
-
     """
-
     return dt.strftime("%Y%m%dT%H%M%SZ")
 
 
@@ -872,7 +857,6 @@ def timestr_to_datetime(time_str):
     :func:`datetime_to_timestr`
 
     """
-
     return datetime.strptime(time_str[:15], "%Y%m%dT%H%M%S")
 
 
@@ -892,7 +876,6 @@ def leap_seconds_between(time_a, time_b):
     int : bool
         The number of leap seconds between *time_a* and *time_b*.
     """
-
     # Construct the elapse UNIX time
     delta_unix = time_b - time_a
 
@@ -932,7 +915,6 @@ def ensure_unix(time):
     unix_time : float, or array of
         Output time.
     """
-
     if isinstance(time[0], datetime):
         return datetime_to_unix(time)
     elif isinstance(time[0], str):
@@ -957,6 +939,7 @@ def naive_datetime_to_utc(dt):
     Parameters
     ----------
     dt : datetime
+        datetime object without 'tzinfo'
 
     Returns
     -------
@@ -986,7 +969,7 @@ def time_of_day(time):
 
     Parameters
     ----------
-    time_date : float (UNIX time), or datetime
+    time : float (UNIX time), or datetime
         Find the start time of the day that `time` is in.
 
     Returns
@@ -1048,10 +1031,11 @@ class SkyfieldWrapper:
 
     @property
     def load(self):
-        """A :class:`skyfield.iokit.Loader` object to be used in the same way as
-        `skyfield.api.load`, in case you want something other than `timescale`
-        or `ephemeris`."""
+        """A :class:`skyfield.iokit.Loader` object.
 
+        This is to be used in the same way as `skyfield.api.load`,
+        in case you want something other than `timescale` or `ephemeris`.
+        """
         if self._load is None:
             raise RuntimeError("Skyfield is not installed.")
         return self._load
@@ -1059,16 +1043,16 @@ class SkyfieldWrapper:
     @property
     def path(self):
         """The path to the Skyfield data."""
-
         return self.load.directory
 
     _timescale = None
 
     @property
     def timescale(self):
-        """A :class:`skyfield.timelib.Timescale` object. Loaded at first call,
-        and then cached."""
+        """A :class:`skyfield.timelib.Timescale` object.
 
+        Loaded at first call and then cached.
+        """
         if self._timescale:
             return self._timescale
 
@@ -1102,8 +1086,9 @@ class SkyfieldWrapper:
     @property
     def ephemeris(self):
         """A Skyfield ephemeris object (:class:`skyfield.jpllib.SpiceKernel`).
-        Loaded at first call, and then cached."""
 
+        Loaded at first call, and then cached.
+        """
         if self._ephemeris:
             return self._ephemeris
 
@@ -1133,7 +1118,6 @@ class SkyfieldWrapper:
 
         This will only load the data from the official sources.
         """
-
         # Download the timescale file and ephemeris
         self.load.download("finals2000A.all")
         self.load.download(self._ephemeris_name)
@@ -1219,7 +1203,6 @@ def skyfield_star_from_ra_dec(ra, dec, name=""):
     body : skyfield.starlib.Star
         An object representing the body.
     """
-
     body = Star(
         ra=Angle(degrees=ra, preference="hours"), dec=Angle(degrees=dec), names=name
     )

--- a/caput/tod.py
+++ b/caput/tod.py
@@ -1,5 +1,4 @@
-"""
-Data formats for Time Ordered Data.
+"""Data formats for Time Ordered Data.
 
 This module contains data containers, data formats, and utilities based on
 :mod:`caput.memh5`. The data represented must have an axis representing time,
@@ -35,9 +34,7 @@ class TOData(memh5.BasicCont):
         """Representation of the "time" axis.
 
         The value of ``self.index_map['time']``.
-
         """
-
         return self.index_map["time"][:]
 
     @classmethod
@@ -53,16 +50,42 @@ class TOData(memh5.BasicCont):
     ):
         """Create new data object by concatenating a series of objects.
 
-        Parameters
-        ----------
-
         Accepts any parameter for :func:`concatenate` (which controls the
         concatenation) or this class's constructor (which controls the
         initialization of each file). By default, each file is opened with
         `ondisk=True` and `mode='r'`.
 
-        """
+        Parameters
+        ----------
+        files : list of :class:`TOData`.
+            These are assumed to be identical in
+            every way except along the axes representing time, over which they
+            are concatenated. All other data and attributes are simply copied
+            from the first entry of the list.
+        data_group : `h5py.Group`, hdf5 filename or `memh5.Group`, optional
+            Underlying hdf5 like container that will store the data for the
+            BaseData instance.
+        start : int or dict with keys ``data_list[0].time_axes``, optional
+            In the aggregate datasets at what index to start.  Every thing before
+            this index is excluded.
+        stop : int or dict with keys ``data_list[0].time_axes``, optional
+            In the aggregate datasets at what index to stop.  Every thing after
+            this index is excluded.
+        datasets : sequence of strings, optional
+            Which datasets to include.  Default is all of them.
+        dataset_filter : callable with one or two arguments
+            Function for preprocessing all datasets.  Useful for changing data
+            types etc. Takes a dataset as an argument and should return a
+            dataset (either h5py or memh5). Optionally may accept a second
+            argument that is slice along the time axis, which the filter should
+            apply.
+        **kwargs : dict
+            Arbitrary keyword arguments.
 
+        Returns
+        -------
+        data : :class:`TOData`
+        """
         if "mode" not in kwargs:
             kwargs["mode"] = "r"
         if "ondisk" not in kwargs:
@@ -86,9 +109,7 @@ class TOData(memh5.BasicCont):
 
         Method accepts scalar times in supported formats and converts them
         to the same format as ``self.time``.
-
         """
-
         return time
 
 
@@ -163,9 +184,7 @@ class Reader:
         -------
         time_sel : pair of ints
             Start and stop indices for reading along the time axis.
-
         """
-
         return self._time_sel
 
     @time_sel.setter
@@ -213,9 +232,7 @@ class Reader:
         stop_time : scalar time
             Affects the second element of :attr:`~Reader.time_sel`.  Default
             leaves it unchanged.
-
         """
-
         if start_time is not None:
             start_time = self.data_class.convert_time(start_time)
             start = np.where(self.time >= start_time)[0][0]
@@ -242,9 +259,7 @@ class Reader:
         data : :class:`TOData`
             Data read from :attr:`~Reader.files` based on the selections made
             by user.
-
         """
-
         return self.data_class.from_mult_files(
             self.files,
             data_group=out_group,
@@ -306,9 +321,7 @@ def concatenate(
     Returns
     -------
     data : :class:`TOData`
-
     """
-
     if dataset_filter is None:
 
         def dataset_filter(d):
@@ -533,12 +546,10 @@ def concatenate(
 
 
 def ensure_file_list(files):
-    """Tries to interpret the input as a sequence of files
+    """Tries to interpret the input as a sequence of files.
 
     Expands filename wildcards ("globs") and casts sequeces to a list.
-
     """
-
     if memh5.is_group(files):
         files = [files]
     elif isinstance(files, str):
@@ -563,9 +574,7 @@ def _copy_non_time_data(
     Return list of all time-order dataset names. Leading '/' is stripped off.
 
     If *out* is `None` do not copy.
-
     """
-
     if to_dataset_names is None:
         to_dataset_names = []
 
@@ -625,7 +634,6 @@ def _copy_non_time_data(
 
 def _dset_has_axis(entry: Any, axes: Tuple[str]) -> bool:
     """Check if `entry` is a dataset with an axis named in `axes`."""
-
     if memh5.is_group(entry):
         return False
 

--- a/caput/tools.py
+++ b/caput/tools.py
@@ -1,5 +1,5 @@
-""" Collection of assorted tools.
-"""
+"""Collection of assorted tools."""
+
 from typing import Iterable
 
 import numpy as np
@@ -15,7 +15,9 @@ def invert_no_zero(x, out=None):
     Parameters
     ----------
     x : np.ndarray
-    out : np.ndarray
+        Array to invert
+    out : np.ndarray, optional
+        Output array to insert results
 
     Returns
     -------
@@ -78,7 +80,9 @@ def allequal(obj1, obj2):
     Parameters
     ----------
     obj1 : scalar, list, tuple, dict, or np.ndarray
+        Object to compare
     obj2 : scalar, list, tuple, dict, or np.ndarray
+        Object to compare
     """
     try:
         _assert_equal(obj1, obj2)
@@ -100,7 +104,9 @@ def _assert_equal(obj1, obj2):
     Parameters
     ----------
     obj1 : scalar, list, tuple, dict, or np.ndarray
+        Object to compare
     obj2 : scalar, list, tuple, dict, or np.ndarray
+        Object to compare
     """
     __tracebackhide__ = True
     if isinstance(obj1, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,34 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython', 'oldest-supported-numpy']
+requires = ["setuptools", "wheel", "Cython", "oldest-supported-numpy"]
+
+[tool.ruff]
+# Enable pycodestyle ('E'), pydocstyle ('D'), pyflakes ('F')
+select = ["E", "D", "F"]
+
+# E203, W503
+ignore = [
+    "E501", # E501: line length violations. Enforce these with `black`
+    "E741", # E741: Ambiguous variable name
+    "D105", # D105: Missing docstring in magic method
+    "D107", # D107: Missing docstring in init
+    "D203", # D203: 1 blank line required before class docstring
+    "D213", # D213: Multi-line docstring summary should start at the second line
+    "D400", # D400: First line should end with a period (only ignoring this because there's another error that catches the same thing)
+    "D401", # D401: First line should be in imperative mood
+    "D402", # D402: First line should not be the function’s “signature”
+    "D413", # D413: Missing blank line after last section
+    "D416", # D416: Section name should end with a colon
+]
+
+# Ignore the following directories
+exclude = [
+    ".git",
+    ".github",
+    "build",
+    "doc",
+    "tests",
+    "setup.py",
+    "versioneer.py",
+]
+
+target-version = "py311"


### PR DESCRIPTION
This PR adds some additional linting to the CI pipeline, including:
- ~~pydocstyle (docstring formatting from PEP 257)~~
- ~~flake8: add E266 check (multiple hashes to start a comment)~~
- Use [ruff](https://github.com/charliermarsh/ruff) for linting, including flake8 and pydocstyle errors
- Remove "ignore" for E266, E203, W503

It also fixes all existing docstring issues in this repo, ignoring the "tests" directory.

Ignore the following pydocstyle errors:
- D105: Missing docstring in magic method
- D107: Missing docstring in __init__
- D203: 1 blank line required before class docstring
- D213: Multi-line docstring summary should start at the second line
- D400: First line should end with a period _(only ignoring this because there's another error that catches the same thing)_
- D401: First line should be in imperative mood
- D402: First line should not be the function’s “signature”
- D413: Missing blank line after last section
- D416: Section name should end with a colon