### PR TITLE
fix(memh5): fix a bug where shared datasets weren't actually shared

### DIFF
--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -2701,8 +2701,20 @@ def deep_group_copy(
     # If copying to file, datasets are not shared, so ensure that these
     # datasets are properly processed
     if to_file:
-        shared = {}
-        shallow = False
+        if shared:
+            warnings.warn(
+                f"Attempted to share datasets {(*shared,)}, but target group "
+                f"{g2} is on disk. Datasets cannot be shared."
+            )
+            shared = {}
+
+        if shallow:
+            warnings.warn(
+                f"Attempted to make a shallow copy of group {g1}, but target "
+                f"group {g2} is on disk. Datasets cannot be shared."
+            )
+            shallow = False
+
     elif not shallow:
         # Make sure shared dataset names are properly formatted
         shared = {"/" + k if k[0] != "/" else k for k in shared}

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -2655,12 +2655,6 @@ def deep_group_copy(
             # Unicode characters before writing
             data = check_unicode(entry)
 
-        if not to_file:
-            # reading from h5py can result in arrays with explicit endian set
-            # which mpi4py cannot handle when Bcasting memh5.Group
-            # needed until fixed: https://github.com/mpi4py/mpi4py/issues/177
-            data = ensure_native_byteorder(data)
-
         dset_args = {"dtype": data.dtype, "shape": data.shape, "data": data}
         # If we're copying memory to memory we can allow distributed datasets
         if not to_file and isinstance(dset, MemDatasetDistributed):


### PR DESCRIPTION
This PR makes the `shared` argument in `MemDiskGroup` actually share the `MemDataset` object and not just the underlying data array. Based on the idea of shared datasets being maintained through operations such as redistribution, axis downselection is not allowed for shared datasets.

It's important to note that the __default__ behaviour of `memh5.deep_group_copy` is (and has been since inception) to only make a _shallow_ copy of the `MemDataset` - i.e., the underlying array is actually shared. It doesn't matter when using this method to copy from disk -> memory or memory-> disk, but it does have implications when copying memory -> memory. This _probably_ shouldn't be the default behaviour, but we would have to be extremely careful if making any changes to avoid breaking anything.  

I've also updated the docstring for `deep_group_copy` to make note of the copy behaviour.

This lets us remove the `.copy` method in `draco.ContainerBase` as it will properly replicate that behaviour (see radiocosmology/draco#231)

~~Also, add an option to skip specific datasets when copying.~~