### PR TITLE
fix: cython fails to compile unless directives at top of file

### DIFF
--- a/caput/weighted_median.pyx
+++ b/caput/weighted_median.pyx
@@ -1,7 +1,8 @@
-"""Weighted Median Functions"""
-
 # distutils: language = c++
 # cython: language_level = 2
+
+"""Weighted Median Functions"""
+
 import numpy as np
 
 from libcpp.memory cimport shared_ptr


### PR DESCRIPTION
The `weighted_median.pyx` cython file was failing to compile for me, because somehow cython was interpreting a bunch of objects as Python when they weren't.

I'm not sure why this only became an issue for me now, but this seems to have fixed it. I just had to move the compiler directive comments to the top of the file.

I would appreciate if anyone with more cython experience could give some insight.