### PR TITLE
fix(pyx): ensure distutil directives are read and pin max numpy version 

### DIFF
--- a/caput/time.py
+++ b/caput/time.py
@@ -344,6 +344,7 @@ class Observer:
         ----------
         lsd : float or array of
             Local Stellar Day to convert to unix
+
         Returns
         -------
         time :  float or array of

--- a/caput/truncate.pyx
+++ b/caput/truncate.pyx
@@ -1,6 +1,6 @@
-"""Routines for truncating data to a specified precision."""
-
 # cython: language_level=3
+
+"""Routines for truncating data to a specified precision."""
 
 cimport cython
 from cython.parallel import prange

--- a/caput/weighted_median.pyx
+++ b/caput/weighted_median.pyx
@@ -1,7 +1,8 @@
-"""Weighted Median Functions"""
-
 # distutils: language = c++
 # cython: language_level = 2
+
+"""Weighted Median Functions"""
+
 import numpy as np
 
 from libcpp.memory cimport shared_ptr

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 click
 cython
 h5py
-numpy>=1.20
+numpy>=1.20,<1.25
 psutil
 PyYAML
 scipy


### PR DESCRIPTION
This PR should address two things:
- Moving distutil directives to the top of the files so they compile properly (#244 #245 )
- Pinning a maximum numpy version 1.24. Numpy 1.25 seems to change some things under the hood with certain ufuncs which can cause unexpected behaviour with mpiarray, so we should review these changes and make any necessary changes before supporting numpy 1.25 (#247). We don't actually use numpy > 1.24 anywhere, so this should be ok for the time being