### PR TITLE
fix(runner): reset the environment to stop crash at job start

### DIFF
--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -2,6 +2,7 @@
 
 import itertools
 import os
+import subprocess
 import sys
 from pathlib import Path
 import tempfile
@@ -565,7 +566,10 @@ fi
     with open(jobdir / "jobscript.sh", "w") as f:
         f.write(script)
     if submit:
-        os.system("cd %s; %s jobscript.sh" % (jobdir, job_command))
+        # NOTE: explicitly set the environment to what Python thinks it should
+        # be. This is because mpi4py will incorrectly modify the environment
+        # using lowlevel calls which Python cannot detect.
+        subprocess.run([job_command, "jobscript.sh"], cwd=jobdir, env=os.environ)
 
 
 def expandpath(path):


### PR DESCRIPTION
Before a job is submitted mpi4py modifies the environment in
a way that is invisible to Python. This modified environment is
inherited by the submitted jobs and was causing them to crash. This
change resets the environment for the subprocess that submits that job.
