### PR TITLE
fix numpy median

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 click
 cython
 h5py
-numpy>=1.20,<1.25
+numpy>=1.20
 psutil
 PyYAML
 scipy


### PR DESCRIPTION
- test(mpiarray): check that median works with numpy >= 1.25
- chore: remove pin from numpy version
