### PR TITLE
Add email notification options for batch jobs

### DIFF
--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -64,7 +64,7 @@ def lint_config(configfile):
 
 
 def load_venv(configfile):
-    """Load the venv specified under cluster/venv in the give configfile."""
+    """Load the venv specified under cluster/venv in the given configfile."""
     import site
     import yaml
 
@@ -356,7 +356,7 @@ def queue(
         A name of the cluster that we are running on, if this is supported
         (currently ``gpc`` and ``cedar``), this uses more relevant default
         values.
-    ``queue_system``
+    ``queue_sys``
         The queue system to run on. Either ``pbs`` or ``slurm``.
     ``queue``
         The queue to submit to. Only used for *PBS*


### PR DESCRIPTION
This adds command-line options to `caput-pipeline` to get slurm or PBS to email a specific address when certain job events take place (e.g. begin, fail), inheriting the options from each scheduling system. I've only tested it on slurm (cedar), but the PBS syntax seems simple enough that it should work as well...