### PR TITLE
Runner: module force purge and module use

### DIFF
--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -550,9 +550,7 @@ class Manager(config.Reader):
         try:
             if not isinstance(yaml_params["pipeline"], dict):
                 raise config.CaputConfigError(
-                    "Value 'pipeline' in YAML configuration is of type '{}' (expected a YAML block here).".format(
-                        type(yaml_params["pipeline"]).__name__
-                    ),
+                    f"Value 'pipeline' in YAML configuration is of type '{type(yaml_params['pipeline']).__name__}' (expected a YAML block here).",
                     location=yaml_params,
                 )
         except TypeError as e:


### PR DESCRIPTION
Add a `--force` flag to `module purge` and add a `module use` option to pipeline runner.

Also remove deprecated `system_packages` from `.readthedocs.yml`. see https://blog.readthedocs.com/drop-support-system-packages/ 