### PR TITLE
fix(requirements): add versioneer install requirement

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx >= 5.0, <7.0
+Sphinx
 sphinx_rtd_theme
 # funcsigs required by mock, which apparently does not have its dependencies
 # setup correctly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ psutil
 PyYAML
 scipy
 skyfield>=1.31
+versioneer
+


### PR DESCRIPTION
Fixes chime-experiment/mkchimeenv#5

Also:
1. Remove sphinx version pin since newer versions works fine now

Items below have now been resolved in other PRs.
~~2. Update with some black formatting changes.~~

~~I've had to pin `pytest < 8.0.0` and `pluggy < 1.4.0` to get the CI tests to pass. See #262~~