### PR TITLE
Pipeline tasks can return multiple outputs to unpack

### DIFF
--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -871,7 +871,7 @@ class Manager(config.Reader):
         # Validate that all inputs have a corresponding output key.
         self._validate_task_inputs()
 
-        # Setup all tasks in the task listk
+        # Setup all tasks in the task list
         for ii, task_spec in enumerate(self.task_specs):
             try:
                 # Load the task instance and add it to the pipeline

--- a/caput/tests/conftest.py
+++ b/caput/tests/conftest.py
@@ -87,7 +87,7 @@ class CookEggs(IterBase):
 
     def process(self, _input):
         """Run process."""
-        print("Cooking %s %s eggs." % (self.style, input))
+        print("Cooking %s %s eggs." % (self.style, _input))
 
     def finish(self):
         """Run finish."""
@@ -120,6 +120,25 @@ pipeline:
       in: egg
 eggs_params:
   eggs: ['green', 'duck', 'ostrich']
+cook_params:
+  style: 'fried'
+"""
+
+multi_eggs_pipeline_conf = """
+---
+pipeline:
+  tasks:
+    - type: caput.tests.conftest.GetEggs
+      params: eggs_params
+      out: [color, egg]
+    - type: caput.tests.conftest.CookEggs
+      params: cook_params
+      in: egg
+    - type: caput.tests.conftest.CookEggs
+      params: cook_params
+      in: color
+eggs_params:
+  eggs: [['green', 'duck'], ['blue', 'ostrich']]
 cook_params:
   style: 'fried'
 """

--- a/caput/tests/test_pipeline.py
+++ b/caput/tests/test_pipeline.py
@@ -8,3 +8,10 @@ def test_pipeline():
     result = conftest.run_pipeline()
     print(result.output)
     assert result.exit_code == 0
+
+
+def test_pipeline_multiple_outputs():
+    """Test running a very simple pipeline with a multi-output task."""
+    result = conftest.run_pipeline(configstr=conftest.multi_eggs_pipeline_conf)
+    print(result.output)
+    assert result.exit_code == 0


### PR DESCRIPTION
- test(pipeline): ensure multiple output pipeline tasks are supported
- fix(pipeline): pipeline tasks can return multiple outputs to unpack
