### PR TITLE
Pin numpy < 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools
 click
 cython
 h5py
-numpy>=1.20
+numpy>=1.20, <2
 psutil
 PyYAML
 scipy


### PR DESCRIPTION
At the moment, there are no available bitshuffle wheels built for `numpy>=2`. Also, our `weighted_median` module has some compatibility issues with `numpy >= 2`. For now I've just pinned `numpy < 2` until I can figure out these incompatibilities 