### PR TITLE
Increase minimum python to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
 
     runs-on: ubuntu-latest
     steps:

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -241,7 +241,8 @@ import logging
 import os
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Union
 
 if TYPE_CHECKING:
     from mpi4py import MPI
@@ -1325,8 +1326,8 @@ class MPIArray(np.ndarray):
         """
 
         def _check_shapes(
-            current_shape: Tuple[int], new_shape: Tuple[int]
-        ) -> Tuple[int]:
+            current_shape: tuple[int], new_shape: tuple[int]
+        ) -> tuple[int]:
             """Check that we can reshape one array into another.
 
             Returns the fully fleshed out shape, or raises a ValueError.
@@ -1400,7 +1401,7 @@ class MPIArray(np.ndarray):
             self.comm,
         )
 
-    def _prep_buf(self, x: np.ndarray) -> Tuple[np.ndarray, "MPI.Datatype"]:
+    def _prep_buf(self, x: np.ndarray) -> tuple[np.ndarray, "MPI.Datatype"]:
         """Prepare a buffer for sending/recv by mpi4py.
 
         If this is array is a supported datatype it just returns a simple buffer spec,
@@ -2173,7 +2174,7 @@ def _get_common_comm(
 def _mpi_to_ndarray(
     inputs: Sequence[Union[MPIArray, npt.ArrayLike, None]],
     only_mpiarray: bool = False,
-) -> Tuple[Union[npt.ArrayLike, None], ...]:
+) -> tuple[Union[npt.ArrayLike, None], ...]:
     # ) -> Tuple[List[Union[np.ndarray, None]], int, "MPI.IntraComm"]:
     """Ensure a list with mixed MPIArrays and ndarrays are all ndarrays.
 
@@ -2241,8 +2242,8 @@ def _create_or_get_dset(group, name, shape, dtype, **kwargs):
 
 
 def sanitize_slice(
-    sl: Tuple[Any], naxis: int
-) -> Tuple[Tuple[Any], Tuple[int], Tuple[int]]:
+    sl: tuple[Any], naxis: int
+) -> tuple[tuple[Any], tuple[int], tuple[int]]:
     """Sanitize and extract information from the arguments to an array indexing.
 
     Parameters

--- a/caput/tod.py
+++ b/caput/tod.py
@@ -8,7 +8,7 @@ sensible operation.
 
 import glob
 import inspect
-from typing import Any, Tuple
+from typing import Any
 
 import h5py
 import numpy as np
@@ -645,7 +645,7 @@ def _copy_non_time_data(
     return [n[1:] if n[0] == "/" else n for n in to_dataset_names]
 
 
-def _dset_has_axis(entry: Any, axes: Tuple[str]) -> bool:
+def _dset_has_axis(entry: Any, axes: tuple[str]) -> bool:
     """Check if `entry` is a dataset with an axis named in `axes`."""
     if memh5.is_group(entry):
         return False

--- a/caput/tools.py
+++ b/caput/tools.py
@@ -1,12 +1,11 @@
 """Collection of assorted tools."""
 
 from collections import deque
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from itertools import chain
 from numbers import Number
 from sys import getsizeof
 from types import ModuleType
-from typing import Iterable
 
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ exclude = [
     "*/__init__.py",
 ]
 
-target-version = "py38"
+target-version = "py39"
 
 [tool.versioneer]
 VCS = "git"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         [console_scripts]
         caput-pipeline=caput.scripts.runner:cli
     """,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requires,
     extras_require={
         "mpi": ["mpi4py>=1.3"],


### PR DESCRIPTION
Python 3.8 will reach end-of-life in October 2024, so we should increase the minimum supported version 