### PR TITLE
feat(interferometry): Import from ch_util and driftscan

### DIFF
--- a/caput/tests/test_interferometry.py
+++ b/caput/tests/test_interferometry.py
@@ -1,0 +1,61 @@
+"""Test interferometry routines."""
+
+import pytest
+from math import pi, sqrt
+
+from caput import interferometry
+
+
+def test_sphdist():
+    from skyfield.units import Angle
+
+    # 90 degrees
+    assert interferometry.sphdist(
+        Angle(radians=0), Angle(radians=0), Angle(radians=pi / 2), Angle(radians=0)
+    ).radians == pytest.approx(pi / 2)
+    assert interferometry.sphdist(
+        Angle(radians=0), Angle(radians=0), Angle(radians=0), Angle(radians=pi / 2)
+    ).radians == pytest.approx(pi / 2)
+
+    # 60 degrees
+    assert interferometry.sphdist(
+        Angle(radians=0), Angle(radians=0), Angle(radians=pi / 4), Angle(radians=pi / 4)
+    ).radians == pytest.approx(pi / 3)
+    assert interferometry.sphdist(
+        Angle(radians=pi / 4), Angle(radians=pi / 4), Angle(radians=0), Angle(radians=0)
+    ).radians == pytest.approx(pi / 3)
+
+
+def test_rotate_ypr():
+
+    # No rotation
+    basis = interferometry.rotate_ypr([0, 0, 0], 1, 2, 3)
+    assert basis == pytest.approx([1, 2, 3])
+
+    # Rotate into +Y two ways
+    basis = interferometry.rotate_ypr([pi / 2, 0, 0], 1, 0, 0)
+    assert basis == pytest.approx([0, 1, 0])
+
+    basis = interferometry.rotate_ypr([0, pi / 2, 0], 0, 0, 1)
+    assert basis == pytest.approx([0, 1, 0])
+
+    # General rotation
+    x0 = sqrt(2) / 2
+    y0 = 0.5
+    z0 = 0.5
+    basis = interferometry.rotate_ypr([pi / 2, pi / 3, pi / 4], x0, y0, z0)
+
+    # The calculation goes like this ("v" denotes a square root):
+
+    # After yawing by 90 degrees:
+    # x1 = -y0               y1 = x0                     z1 = z0
+
+    # Then pitching by 60 degrees:
+    # x2 = x1                y2 = 0.5 * y1 + v3/2 z1     z2 = -v3/2 y1 + 0.5 z1
+
+    # Then rolling by 45 degrees:
+    # x3 = v2/2 (x2 - z2)    y3 = y2                     z3 = v2/2 (x2 + z2)
+
+    assert basis[0] == pytest.approx(sqrt(2) / 2 * (-y0 + sqrt(3) * x0 / 2 - z0 / 2))
+    assert basis[1] == pytest.approx(x0 / 2 + sqrt(3) * z0 / 2)
+    assert basis[2] == pytest.approx(sqrt(2) / 2 * (-y0 - sqrt(3) * x0 / 2 + z0 / 2))

--- a/caput/tools.py
+++ b/caput/tools.py
@@ -140,7 +140,7 @@ def _assert_equal(obj1, obj2):
     # If both objects are np.ndarray subclasses, check that they
     # have the same type
     if isinstance(obj1, np.ndarray) and isinstance(obj2, np.ndarray):
-        assert type(obj1) == type(obj2)
+        assert type(obj1) is type(obj2)
 
         obj1 = obj1.view(np.ndarray)
         obj2 = obj2.view(np.ndarray)


### PR DESCRIPTION
This imports two general-purpose angle-related functions from other modules using caput, with the intention of re-exporting them back to those modules:

* `rotate_ypr`: rotates a 3-basis by a yaw, pitch, and roll. Originally from drifscan: https://github.com/radiocosmology/driftscan/blob/8def16f7d1f9d35f729305dd8998c40a7cb7aceb/drift/telescope/cylbeam.py#L44
* `sphdist`: calculates the angular distance betwee two points on the sphere.  Originally from ch_util: https://github.com/chime-experiment/ch_util/blob/c460b37b27f5bcaa1dfbe7897f3ade88e6e6775b/ch_util/ephemeris.py#L358

I have made some minor changes to the docstrings.  There are also some very rudimentary unit tests.