### PR TITLE
Remove deprecated cached_property in favour of functools.cached_property

### DIFF
--- a/caput/cache.py
+++ b/caput/cache.py
@@ -1,7 +1,5 @@
 """Tools for caching expensive calculations."""
 
-import weakref
-
 import numpy as np
 from cachetools import LRUCache
 
@@ -26,50 +24,3 @@ class NumpyCache(LRUCache):  # pylint: disable=too-many-ancestors
             return arr.nbytes
 
         super().__init__(maxsize=size_bytes, getsizeof=_array_size)
-
-
-class cached_property:
-    """An immutable cached property.
-
-    This exists in Python 3.8, and later but we're restricted to Python 3.6.
-
-    Example
-    -------
-    >>> class A:
-    ...     @cached_property
-    ...     def v(self):
-    ...         print("I'm in here")
-    ...         return 2
-
-    >>> a = A()
-    >>> a.v
-    I'm in here
-    2
-    >>> a.v
-    2
-    >>> a.v = 4
-    Traceback (most recent call last):
-       ...
-    AttributeError: Can't set attribute
-    """
-
-    def __init__(self, func, doc=None):
-        self.func = func
-        if doc is None:
-            doc = func.__doc__
-        self.__doc__ = doc
-        self._value_cache = weakref.WeakKeyDictionary()
-
-    def __get__(self, obj, objtype=None):
-        if obj is None:
-            return self
-
-        try:
-            return self._value_cache[obj]
-        except KeyError:
-            val = self.func(obj)
-            self._value_cache[obj] = val
-            return val
-
-    def __set__(self, *args):
-        raise AttributeError("Can't set attribute")


### PR DESCRIPTION
This is only used in a couple of places, so there will be separate PRs to fix that