### PR TITLE
Interactive pipeline debugging

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 import pytest
 
-from caput.pipeline import PipelineStopIteration, TaskBase, IterBase
+from caput.pipeline import PipelineStopIteration, TaskBase, IterBase, Manager
 from caput.scripts.runner import cli
 from caput import config, fileformats, mpiutil
 
@@ -154,6 +154,46 @@ cook_params:
                 return runner.invoke(cli, ["run", *parameters, configfile.name])
 
     return _run_pipeline
+
+
+@pytest.fixture
+def get_pipeline():
+    """Provides the `get_pipeline` function which returns an initialized pipeline manager."""
+    eggs_pipeline_conf = """
+---
+pipeline:
+  tasks:
+    - type: tests.conftest.PrintEggs
+      params: eggs_params
+    - type: tests.conftest.GetEggs
+      params: eggs_params
+      out: egg
+    - type: tests.conftest.CookEggs
+      params: cook_params
+      in: egg
+eggs_params:
+  eggs: ['green', 'duck', 'ostrich']
+cook_params:
+  style: 'fried'
+"""
+
+    def _get_pipeline(configstr=eggs_pipeline_conf):
+        """Initialize a pipeline manager object.
+
+        Parameters
+        ----------
+        configstr : str
+            YAML string to use as a config.
+
+        Returns
+        -------
+        manager : Manager
+            Initialized pipeline manager.
+        """
+
+        return Manager.from_yaml_str(configstr)
+
+    return _get_pipeline
 
 
 @pytest.fixture

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -33,3 +33,89 @@ cook_params:
     result = run_pipeline(configstr=multi_eggs_pipeline_conf)
     print(result.output)
     assert result.exit_code == 0
+
+
+def test_manual_pipeline_interactive(get_pipeline):
+    """Test running a pipeline with interactive mode enabled.
+
+    Manually walk through each step of the config and check that
+    tasks are exectued as expected. Breakpoints should have no
+    effect.
+    """
+
+    interactive_eggs_pipeline_conf = """
+---
+pipeline:
+  interactive: true
+  enable_breakpoints: true
+  tasks:
+    - type: tests.conftest.PrintEggs
+      params: eggs_params
+    - type: tests.conftest.GetEggs
+      params: eggs_params
+      out: egg
+    - type: tests.conftest.CookEggs
+      params: cook_params
+      in: egg
+eggs_params:
+  eggs: ['green', 'duck', 'ostrich']
+  breakpoint: true
+cook_params:
+  style: 'fried'
+"""
+
+    manager = get_pipeline(configstr=interactive_eggs_pipeline_conf)
+    # Get the pipeline runner generator
+    runner = manager.runner()
+
+    # Skip through setup state
+    for _ in range(4):
+        next(runner)
+
+    # Check that all tasks are in the expected state
+    assert manager._task_idx == 0
+    for task in manager.tasks:
+        assert task._pipeline_state == "next"
+
+    # Run the pipeline to the end
+    while True:
+        try:
+            next(runner)
+        except StopIteration:
+            break
+
+    # Verify that the pipeline is complete
+    assert all(task is None for task in manager.tasks)
+
+
+def test_manual_pipeline(get_pipeline):
+    """Test running a pipeline with interactive mode and breakpoints disabled."""
+
+    breakpoint_eggs_pipeline_conf = """
+---
+pipeline:
+  interactive: false
+  enable_breakpoints: false
+  tasks:
+    - type: tests.conftest.PrintEggs
+      params: eggs_params
+    - type: tests.conftest.GetEggs
+      params: eggs_params
+      out: egg
+    - type: tests.conftest.CookEggs
+      params: cook_params
+      in: egg
+eggs_params:
+  eggs: ['green']
+  breakpoint: true
+cook_params:
+  style: 'fried'
+"""
+
+    manager = get_pipeline(configstr=breakpoint_eggs_pipeline_conf)
+
+    # Run the pipeline
+    manager.run()
+
+    # Verify that the pipeline is complete
+    assert all(task is None for task in manager.tasks)


### PR DESCRIPTION
Add two features mentioned in #19
1. Add an interactive pipeline mode by creating a generator object which yields after each pipeline iteration
2. Add a task breakpoint parameter which, when triggered, causes the pipeline to stop and drop into `pdb` for debugging

Lingering questions:
- When a task has a breakpoint, breakpoint is triggered each time the task is called. Should it only happen once?

Also add tests for normal and interactive pipeline operation.

I'm open to suggestions for alternative ways to implement this.