### PR TITLE
Numpy 2.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
 
       - name: Install pip dependencies
         run: |
-          pip install -e .
-          pip install -e .[lint]
+          pip install black ruff
 
       - name: Run ruff (flake8 and pydocstyle)
         run: ruff check .
@@ -57,6 +56,7 @@ jobs:
 
     - name: Install pip dependencies
       run: |
+        pip install -e .
         pip install -e .[compression,mpi,test]
 
     - name: Run serial tests
@@ -88,8 +88,8 @@ jobs:
 
     - name: Install pip dependencies
       run: |
-        pip install -e .
-        pip install -e .[docs]
+        pip install .
+        pip install .[docs]
 
     - name: Build sphinx docs
       run: sphinx-build -W -b html doc/ doc/_build/html

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -80,6 +80,12 @@ except ImportError as err:
 else:
     zarr_available = True
 
+# This needs to be set for doctests to pass on numpy 2.0. In numpy 2.0+,
+# the repr of a numpy scalar include the type information - i.e. a numpy
+# scalar is printed as 'np.float64(3.0)' rather than just '3.0'.
+# https://numpy.org/doc/stable/release/2.0.0-notes.html#representation-of-numpy-scalars-changed
+np.set_printoptions(legacy="1.25")
+
 # Basic Classes
 # -------------
 

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -254,6 +254,12 @@ from caput import fileformats, misc, mpiutil
 
 logger = logging.getLogger(__name__)
 
+# This needs to be set for doctests to pass on numpy 2.0. In numpy 2.0+,
+# the repr of a numpy scalar include the type information - i.e. a numpy
+# scalar is printed as 'np.float64(3.0)' rather than just '3.0'.
+# https://numpy.org/doc/stable/release/2.0.0-notes.html#representation-of-numpy-scalars-changed
+np.set_printoptions(legacy="1.25")
+
 
 class _global_resolver:
     # Private class implementing the global sampling for MPIArray

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -19,7 +19,7 @@ Fourier transforming each of these two axes of the distributed array::
 
     # Load in data into parallel array
     for lfi, fi in darr1.enumerate(axis=0):
-        darr1[lfi] = load_freq_data(gfi)
+        darr1.local_array[lfi] = load_freq_data(gfi)
 
     # Perform m-transform (i.e. FFT)
     darr2 = MPIArray.wrap(np.fft.fft(darr1, axis=1), axis=0)

--- a/caput/time.py
+++ b/caput/time.py
@@ -124,7 +124,7 @@ and a complete cycle of ERA.
 """
 
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 
 import numpy as np
 from scipy.optimize import brentq
@@ -982,7 +982,7 @@ def era_to_unix(era, time0):
 def unix_to_datetime(unix_time):
     """Converts unix time to a :class:`~datetime.datetime` object.
 
-    Equivalent to :meth:`datetime.datetime.utcfromtimestamp`.
+    Equivalent to timezone-aware :meth:`datetime.datetime.fromtimestamp`.
 
     Parameters
     ----------
@@ -998,7 +998,7 @@ def unix_to_datetime(unix_time):
     --------
     :func:`datetime_to_unix`
     """
-    dt = datetime.utcfromtimestamp(unix_time)
+    dt = datetime.fromtimestamp(unix_time, timezone.utc)
 
     return naive_datetime_to_utc(dt)
 
@@ -1026,7 +1026,7 @@ def datetime_to_unix(dt):
     """
     # Noting that this operation is ignorant of leap seconds.
     dt = naive_datetime_to_utc(dt)
-    epoch_start = naive_datetime_to_utc(datetime.utcfromtimestamp(0))
+    epoch_start = naive_datetime_to_utc(datetime.fromtimestamp(0, timezone.utc))
     since_epoch = dt - epoch_start
     return since_epoch.total_seconds()
 
@@ -1195,7 +1195,7 @@ def time_of_day(time):
     time : float
         Time since start of UTC day in seconds.
     """
-    dt = datetime.utcfromtimestamp(ensure_unix(time))
+    dt = datetime.fromtimestamp(ensure_unix(time), timezone.utc)
     d = dt.replace(hour=0, minute=0, second=0, microsecond=0)
     return (dt - d).total_seconds()
 

--- a/caput/weighted_median.pyx
+++ b/caput/weighted_median.pyx
@@ -12,6 +12,9 @@ from MedianTree cimport Tree, Data
 cimport numpy as np
 cimport cython
 
+# Required for numpy 2.0 compatibility
+np.import_array()
+
 # Define the fused types that can be used for the data or weights in the median routine
 ctypedef fused data_t:
     int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "setuptools-git-versioning",
     "cython",
-    "oldest-supported-numpy",
+    "numpy>=2.0.0rc1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -26,7 +26,7 @@ dependencies = [
     "click",
     "cython",
     "h5py",
-    "numpy>=1.20, <2",
+    "numpy>=1.24",
     "psutil",
     "PyYAML",
     "scipy",

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,7 +1,7 @@
 import os
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import numpy as np
 import pytest
@@ -254,7 +254,7 @@ def test_from_unix_time():
     """
 
     unix_time = random.random() * 2e6
-    dt = datetime.utcfromtimestamp(unix_time)
+    dt = datetime.fromtimestamp(unix_time, timezone.utc)
     st = ctime.unix_to_skyfield_time(unix_time)
     new_dt = st.utc_datetime()
     assert dt.year == new_dt.year
@@ -287,7 +287,7 @@ def test_time_precision():
 
 def test_datetime_to_unix():
     unix_time = time.time()
-    dt = datetime.utcfromtimestamp(unix_time)
+    dt = datetime.fromtimestamp(unix_time, timezone.utc)
     new_unix_time = ctime.datetime_to_unix(dt)
     assert new_unix_time == approx(unix_time, abs=1e-5)
 


### PR DESCRIPTION
- compiles against numpy >= 2.0.0rc1
- calls `np.import_array()` in `weighted_median` to include required headers
- replaces deprecated `datetime.datetime.utcfromtimestamp` with `datetime.datetime.fromtimestamp(..., datetime.timezone.utc)`
- Uses legacy numpy print options - in numpy 2, numpy scalars are printed with type information, i.e. `np.float64(3.0)` instead of `3.0`. This breaks doctests.