### PR TITLE
Fix inadvertent `StopIteration` in MPIArray which triggers the pipeline to end

### DIFF
--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -1821,7 +1821,15 @@ class MPIArray(np.ndarray):
 
         # Find the first MPIArray in the argument list and use this to determine the
         # distributed axis location
-        first_mpi_array = next(inp for inp in inputs if isinstance(inp, MPIArray))
+        try:
+            first_mpi_array = next(inp for inp in inputs if isinstance(inp, MPIArray))
+        except StopIteration as exc:
+            raise TypeError(
+                "MPIArray ufunc didn't get any MPIArray inputs. This probably "
+                "means that the ufunc was called with the `out` argument assigned "
+                " to a MPIArray."
+            ) from exc
+
         axis = max_dim + first_mpi_array.axis - first_mpi_array.ndim
         length = first_mpi_array.global_shape[first_mpi_array.axis]
         offset = first_mpi_array.local_offset[first_mpi_array.axis]

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -600,9 +600,6 @@ class MPIArray(np.ndarray):
 
     def __new__(cls, global_shape, axis=0, comm=None, *args, **kwargs):
         """Make a new MPIArray."""
-        # if mpiutil.world is None:
-        #     raise RuntimeError('There is no mpi4py installation. Aborting.')
-
         if comm is None:
             comm = mpiutil.world
 
@@ -1619,10 +1616,8 @@ class MPIArray(np.ndarray):
         partitions : list of slice objects
             List of slices.
         """
-        from mpi4py import MPI
-
         threshold_bytes = threshold * 2**30
-        largest_size = self.comm.allreduce(self.nbytes, op=MPI.MAX)
+        largest_size = self.comm.allreduce(self.nbytes, op=mpiutil.MAX)
         min_axis_size = int(np.ceil(largest_size / threshold_bytes))
 
         # Return early if we can


### PR DESCRIPTION
The pipeline runner is built as a generator and uses `StopIteration` to signal that it's done. This PR fixes a bug where a ufunc could be called with only numpy array inputs but `out=<mpiarray.MPIArray>`. 