### PR TITLE
Fix mpiarray global_slice Ellipsis check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ pip-log.txt
 .tox
 nosetests.xml
 
+# Unit test files
+*.tmp_test*
+*/perf*
+
 # Translations
 *.mo
 

--- a/caput/config.py
+++ b/caput/config.py
@@ -380,21 +380,18 @@ def list_type(type_=None, length=None, maxlength=None, default=None):
             for ii, item in enumerate(val):
                 if not isinstance(item, type_):
                     raise CaputConfigError(
-                        "Expected to receive a list with items of type %s, but got "
-                        "'%s' of type '%s' at position %i"
-                        % (type_, item, type(item), ii)
+                        f"Expected to receive a list with items of type {type_!s}, but got "
+                        f"'{item!s}' of type '{type(item)!s}' at position {ii}"
                     )
 
         if length and len(val) != length:
             raise CaputConfigError(
-                "List expected to be of length %i, but was actually length %i"
-                % (length, len(val))
+                f"List expected to be of length {length}, but was actually length {len(val)}"
             )
 
         if maxlength and len(val) > maxlength:
             raise CaputConfigError(
-                "Maximum length of list is %i is, but list was actually length %i"
-                % (maxlength, len(val))
+                f"Maximum length of list is {maxlength} is, but list was actually length {len(val)}"
             )
 
         return val

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -881,8 +881,7 @@ class MemGroup(_BaseGroup):
 
         if dset.distributed:
             warnings.warn(
-                "%s is already a distributed dataset, redistribute it along the required axis %d"
-                % (name, distributed_axis)
+                f"{name!s} is already a distributed dataset, redistribute it along the required axis {distributed_axis}"
             )
             dset.redistribute(distributed_axis)
             return dset

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -968,7 +968,7 @@ class MPIArray(np.ndarray):
         # Check that the axis is valid and wrap to an actual position
         if axis < -naxis or axis >= naxis:
             raise AxisException(
-                "Distributed axis %i not in range (%i, %i)" % (axis, -naxis, naxis - 1)
+                f"Distributed axis {axis} not in range ({-naxis}, {naxis - 1})"
             )
         axis = naxis + axis if axis < 0 else axis
 
@@ -1642,9 +1642,8 @@ class MPIArray(np.ndarray):
                 break
         else:
             raise RuntimeError(
-                "Can't identify an IO partition less than %.2f GB in size: "
-                "shape=%s, distributed axis=%i"
-                % (threshold, self.global_shape, self.axis)
+                f"Can't identify an IO partition less than {threshold:.2f} GB in size: "
+                f"shape={self.global_shape!s}, distributed axis={self.axis}"
             )
 
         axis_length = self.global_shape[split_axis]

--- a/caput/mpiarray.py
+++ b/caput/mpiarray.py
@@ -279,8 +279,14 @@ class _global_resolver:
             slobj = (slobj, Ellipsis)
 
         # Add an ellipsis if length of slice object is too short
-        if isinstance(slobj, tuple) and len(slobj) < ndim and Ellipsis not in slobj:
-            slobj = (*slobj, Ellipsis)
+        if isinstance(slobj, tuple) and len(slobj) < ndim:
+            # This is a workaround for the more straightforward
+            # `Ellipsis not in slobj`. If one of the axes is indexed
+            # by a numpy array, the simpler logic will check each element
+            # of the array and will fail. Comparing each object directly
+            # gets around this.
+            if not any(obj is Ellipsis for obj in slobj):
+                slobj = (*slobj, Ellipsis)
 
         # Expand an ellipsis
         slice_list = []


### PR DESCRIPTION
The check `Ellipsis not in slobj` fails if there is a `np.ndarray` in slobj, which ends up checking each object in the tuple **and** each item in the `np.ndarray`, and thus ends up failing with `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`. This change just checks each object in `slobj`, which seems to work.

Also Ruff.