### PR TITLE
Properly propagate error in `bit_truncate_relative`

### DIFF
--- a/caput/truncate.pyx
+++ b/caput/truncate.pyx
@@ -8,6 +8,8 @@ from cython.parallel import prange
 import numpy as np
 cimport numpy as cnp
 
+from libc.math cimport fabs
+
 cdef extern from "truncate.hpp":
     inline int bit_truncate(int val, int err) nogil
 
@@ -229,7 +231,7 @@ def bit_truncate_relative_float(float[:] val, float prec):
     cdef Py_ssize_t i = 0
 
     for i in prange(n, nogil=True):
-        val[i] = _bit_truncate_float(val[i], prec * val[i])
+        val[i] = _bit_truncate_float(val[i], fabs(prec * val[i]))
 
     return np.asarray(val)
 
@@ -258,7 +260,7 @@ def bit_truncate_relative_double(cnp.float64_t[:] val, cnp.float64_t prec):
     cdef Py_ssize_t i = 0
 
     for i in prange(n, nogil=True):
-        val[i] = _bit_truncate_double(val[i], prec * val[i])
+        val[i] = _bit_truncate_double(val[i], fabs(prec * val[i]))
 
     return np.asarray(val, dtype=np.float64)
 

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -126,3 +126,19 @@ def test_truncate_relative():
         )
         == np.asarray([32, 32], dtype=np.float64)
     ).all()
+
+    # Check the case where values are negative
+    assert (
+        truncate.bit_truncate_relative(
+            np.asarray([-32.121, 32.5], dtype=np.float32),
+            0.1,
+        )
+        == np.asarray([-32, 32], dtype=np.float32)
+    ).all()
+    assert (
+        truncate.bit_truncate_relative(
+            np.asarray([-32.121, 32.5], dtype=np.float64),
+            0.1,
+        )
+        == np.asarray([-32, 32], dtype=np.float64)
+    ).all()


### PR DESCRIPTION
Negative values would end up trying to truncate against negative error, which would always return `-0.0`. This makes sure that the error value is positive.