### PR TITLE
Require zarr < 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 
 [project.optional-dependencies]
 mpi = ["mpi4py>=1.3"]
-compression = ["bitshuffle", "numcodecs>=0.7.3", "zarr>=2.11.0"]
+compression = ["bitshuffle", "numcodecs>=0.7.3", "zarr>=2.11.0,<3"]
 profiling = ["pyinstrument"]
 docs = ["Sphinx>=5.0", "sphinx_rtd_theme", "funcsigs", "mock"]
 lint = ["ruff", "black"]


### PR DESCRIPTION
Zarr version 3.0 has a lot of breaking changes (see [here](https://zarr.readthedocs.io/en/stable/user-guide/v3_migration.html)). We should eventually updated `memh5` to address these changes, but for now I'm just pinning the version to less than 3.