### PR TITLE
Import pyfftw before numpy

### DIFF
--- a/caput/fftw.py
+++ b/caput/fftw.py
@@ -49,16 +49,21 @@ Functions
 
 from __future__ import annotations
 
-import numpy as np
-
-from caput import mpiutil
-
+# NOTE: Due to a bug in pyfftw, it needs to be imported before
+# numpy in order to avoid some sort of namespace collision.
+# If you run into a RuntimeError when trying to use the `FFT`
+# class, make sure that your environment imports `pyfftw`
+# before `numpy`. Hopefully this will be fixed soon.
 try:
     import pyfftw
 except ImportError as exc:
     raise ImportError(
         "`pyfftw` is not installed. Install `pyfftw` via `caput[fftw]`."
     ) from exc
+
+import numpy as np
+
+from caput import mpiutil
 
 
 class FFT:

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -1816,8 +1816,7 @@ class MemDiskGroup(_BaseGroup):
             ):
                 file_ = file_.filename
 
-            if "mode" in kwargs:
-                del kwargs["mode"]
+            kwargs.pop("mode", None)
 
             # Look for *_sel parameters in kwargs, collect and remove them from kwargs
             sel_args = {}

--- a/caput/tod.py
+++ b/caput/tod.py
@@ -346,12 +346,12 @@ def concatenate(
 
     # Ensure *start* and *stop* are mappings.
     if not hasattr(start, "__getitem__"):
-        start = {axis: start for axis in concatenation_axes}
+        start = dict.fromkeys(concatenation_axes, start)
     if not hasattr(stop, "__getitem__"):
-        stop = {axis: stop for axis in concatenation_axes}
+        stop = dict.fromkeys(concatenation_axes, stop)
 
     # Get the length of all axes for which we are concatenating.
-    concat_index_lengths = {axis: 0 for axis in concatenation_axes}
+    concat_index_lengths = dict.fromkeys(concatenation_axes, 0)
     for data in data_list:
         for index_name in concatenation_axes:
             if index_name not in data.index_map:
@@ -413,7 +413,7 @@ def concatenate(
     else:
         dataset_names = datasets
 
-    current_concat_index_start = {axis: 0 for axis in concatenation_axes}
+    current_concat_index_start = dict.fromkeys(concatenation_axes, 0)
     # Now loop over the list and copy the data.
     for data in data_list:
         # Get the concatenation axis lengths for this BaseData.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ profiling = ["pyinstrument"]
 docs = ["Sphinx>=5.0", "sphinx_rtd_theme", "funcsigs", "mock"]
 lint = ["ruff", "black"]
 test = ["pytest", "pytest-lazy-fixtures"]
-fftw = ["pyfftw"]
+fftw = ["pyfftw>=0.13.1"]
 
 [project.urls]
 Documentation = "https://caput.readthedocs.io/"


### PR DESCRIPTION
There's a bug in `pyfftw` which seems to cause some sort of namespace issues with `numpy`. It seems like importing `pyfftw` before `numpy` fixes the issue, but this is environment-wide (i.e., it probably won't work in complex pipeline code where numpy is usually one of the first imports). However, I don't see any issue in at least slightly improving peoples chances of having it work.

This bug seems to still exist in the most recent version of `pyfftw`, so hopefully it gets fixed at some point.

Also, some fixes for ruff.