### PR TITLE
Add a flag to deprecate config properties

### DIFF
--- a/caput/config.py
+++ b/caput/config.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from . import fileformats
 
 import logging
+import warnings
 
 from yaml.loader import SafeLoader
 
@@ -67,7 +68,7 @@ logger = logging.getLogger(__name__)
 class Property:
     """Custom property descriptor that can load values from a given dict."""
 
-    def __init__(self, default=None, proptype=None, key=None):
+    def __init__(self, default=None, proptype=None, key=None, deprecated=False):
         """Make a new property type.
 
         Parameters
@@ -82,7 +83,17 @@ class Property:
             The name of the dictionary key that we can fetch this value from.
             If None (default), attempt to use the attribute name from the
             class.
+        deprecated : bool
+            An easy way to flag a property as deprecated. This will raise a deprecation
+            warning, but will not change the behaviour of this `Property` instance.
         """
+        if deprecated:
+            warnings.warn(
+                f"Property {self!r} is deprecated and may behave unpredictably. "
+                "Check the documentation of the class/function where this is being "
+                "initialised to see the recommended solution."
+            )
+
         self.proptype = (lambda x: x) if proptype is None else proptype
         self.default = default
         self.key = key

--- a/caput/pipeline.py
+++ b/caput/pipeline.py
@@ -1490,6 +1490,16 @@ class TaskBase(config.Reader):
 
             if out is not None:
                 self._num_iters += 1
+                # Let the user know if there's a chance that data has been
+                # modified in-place
+                for opt in out if isinstance(out, tuple | list) else (out,):
+                    if opt in args:
+                        logger.debug(
+                            f"Task {self!s} may have modified dataset {opt!r} in-place. "
+                            "If you encounter unexpected results, check that this is "
+                            "the intended behaviour."
+                        )
+
                 # If this task has a restricted number of outputs, it should advance
                 # if enough output iterations have been executed
                 if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 
 [project.optional-dependencies]
 mpi = ["mpi4py>=1.3"]
-compression = ["bitshuffle", "numcodecs>=0.7.3", "zarr>=2.11.0,<3"]
+compression = ["bitshuffle", "zarr>=2.11.0,<3", "numcodecs>=0.7.3,<0.16"]
 profiling = ["pyinstrument"]
 docs = ["Sphinx>=5.0", "sphinx_rtd_theme", "funcsigs", "mock"]
 lint = ["ruff", "black"]


### PR DESCRIPTION
This will be helpful when modifying old tasks.

I've also added a feature to the pipeline base task to add a debug log entry if a task returns the same object as one of the inputs, which suggests that it could have been modified in place. This is mostly for my own use if I'm trying to review weird behaviour in a pipeline config, but I think it's helpful.

There's something broken in the tests from a very recent release of `numcodecs` (https://numcodecs.readthedocs.io/en/stable/release.html#removals). 

There's already an open PR in `zarr` to address it, so I'm just going to leave this PR until that gets merged, because I don't want to have to pin `numcodecs` ourselves. Update: this still wasn't working properly with python 3.13, so I've just pinned `numcodecs`. I think we'll have to keep it pinned until we upgrade to zarr 3 anyway.