### PR TITLE
Make a `fft` module, which contains the existing `fftw` module

### DIFF
--- a/caput/__init__.py
+++ b/caput/__init__.py
@@ -7,7 +7,6 @@ Submodules
 
     cache
     config
-    fftw
     fileformats
     memh5
     misc

--- a/caput/coordinates/__init__.py
+++ b/caput/coordinates/__init__.py
@@ -5,6 +5,6 @@
 
 from . import (
     coord as coord,
-    sphcoords as sphcoords,
+    spherical as spherical,
     sphfunc as sphfunc,
 )

--- a/caput/fft/__init__.py
+++ b/caput/fft/__init__.py
@@ -1,0 +1,12 @@
+"""caput.fft.
+
+Utilities for FFTs.
+
+Features
+========
+- Multi-threaded `scipy.fft` by default
+- Helpers to use `pyFFTW`
+"""
+
+from ._scipy_fft import *  # noqa: F403
+from . import fftw as fftw

--- a/caput/fft/_scipy_fft.py
+++ b/caput/fft/_scipy_fft.py
@@ -1,0 +1,36 @@
+"""Scipy FFT routines.
+
+This module just re-exports `scipy.fft`, but it uses
+all cores by default (instead of one). Users can still
+set the number of cores on a case-by-case basis using
+the standard `scipy` syntax.
+
+For small arrays, it will generally be faster to use a
+single threaded version from `scipy.fft` directly.
+"""
+
+import scipy.fft
+
+from .. import mpiutil
+
+# Overwrite any existing backends on import
+scipy.fft.set_global_backend("scipy", only=True)
+
+# Re-export only from `scipy.fft`
+__all__ = scipy.fft.__all__
+
+# Only use this lookup once
+_nworkers = mpiutil.cpu_count()
+
+
+def _set_workers(func):
+    def _inner(*args, **kwargs):
+        with scipy.fft.set_workers(kwargs.pop("workers", _nworkers)):
+            return func(*args, **kwargs)
+
+    return _inner
+
+
+# Re-export all scipy symbols with multiple workers set
+def __getattr__(name):
+    return _set_workers(getattr(scipy.fft, name))

--- a/caput/fft/fftw.py
+++ b/caput/fft/fftw.py
@@ -63,7 +63,7 @@ except ImportError as exc:
 
 import numpy as np
 
-from caput import mpiutil
+from .. import mpiutil
 
 
 class FFT:


### PR DESCRIPTION
I want an easy way for users to access faster FFTs than what's provided by `numpy.fft` (which is quite slow). I had previously tried to do that with the `fftw` module, which is faster than `numpy/scipy`, but it ended up being finicky and has some annoying bugs. `fftw` is now accessed as a submodule of the `fft` submodule.

At the moment, the main `fft` module just re-exports `scipy.fft` with multiple workers set by default (`scipy` uses `pocketfft` as a backend, so I actually change the number of workers there). A full benchmark would probably be useful, but I've found that the overhead of using multiple workers is nullified quite quickly by the performance gained as arrays grow in size.

Going forward, I want to see if I can find some other, faster options. It should be reasonable to use `mkl`, and [kfr](https://github.com/kfrlib/kfr) seems interesting and has been used by LIGO, but I don't think it has python bindings. I also need to investigate options for AMD cpus, since that's what `fir` will be using.