### PR TITLE
Include 'fir' in pipeline cluster options

### DIFF
--- a/caput/mpiutil.py
+++ b/caput/mpiutil.py
@@ -735,7 +735,7 @@ def transpose_blocks(row_array, shape, comm=_comm):
                 "**** ERROR in MPI RECV (r: %i c: %i rank: %i) *****", ir, ir, comm.rank
             )
 
-    return recv_buffer.reshape(shape[:-1] + (pc,))
+    return recv_buffer.reshape((*shape[:-1], pc))
 
 
 def allocate_hdf5_dataset(fname, dsetname, shape, dtype, comm=_comm):

--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -378,7 +378,7 @@ def queue(
         Only used for slurm.
         A list of modules environments to load before running a job.
         If set, a module purge will occur before loading the specified modules.
-        Sticky modules like StdEnv/* on Fir will not get purged, and
+        Sticky modules like StdEnv/* on Cedar and Fir will not get purged, and
         should not be specified.
         If not set, the current environment is used.
     ``module_path``

--- a/caput/scripts/runner.py
+++ b/caput/scripts/runner.py
@@ -355,7 +355,7 @@ def queue(
     \b
     ``system``
         A name of the cluster that we are running on, if this is supported
-        (currently ``gpc`` and ``cedar``), this uses more relevant default
+        (currently ``gpc``, ``cedar``, ``fir``), this uses more relevant default
         values.
     ``queue_sys``
         The queue system to run on. Either ``pbs`` or ``slurm``.
@@ -378,7 +378,7 @@ def queue(
         Only used for slurm.
         A list of modules environments to load before running a job.
         If set, a module purge will occur before loading the specified modules.
-        Sticky modules like StdEnv/* on Cedar will not get purged, and
+        Sticky modules like StdEnv/* on Fir will not get purged, and
         should not be specified.
         If not set, the current environment is used.
     ``module_path``
@@ -427,6 +427,7 @@ def queue(
     system_defaults = {
         "gpc": {"ppn": 8, "mem": "16000M", "queue_sys": "pbs", "account": None},
         "cedar": {"ppn": 32, "mem": "0", "queue_sys": "slurm", "account": "rpp-chime"},
+        "fir": {"ppn": 32, "mem": "0", "queue_sys": "slurm", "account": "rpp-chime"},
     }
 
     # Start to generate the full resolved config


### PR DESCRIPTION
I'm planning to rework this a bit so we don't have these hard-coded cluster options, but this is just a quick fix for now