### PR TITLE
Re-enable parallel compression for hdf5 files

### DIFF
--- a/caput/fileformats.py
+++ b/caput/fileformats.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 try:
     import zarr
-except ImportError as err:
-    logger.info(f"zarr support disabled. Install zarr to change this: {err}")
+except ImportError:
+    logger.debug("zarr support disabled. Install zarr to change this.")
     zarr_available = False
 else:
     zarr_available = True
@@ -19,14 +19,25 @@ else:
 try:
     import numcodecs
     from bitshuffle.h5 import H5_COMPRESS_LZ4, H5FILTER
-except ModuleNotFoundError as e:
+except ModuleNotFoundError:
     logger.debug(
-        f"Install with 'compression' extra_require to use bitshuffle/numcodecs compression filters.: {e}"
+        "Install with 'compression' extra_require to use bitshuffle/numcodecs compression filters."
     )
     compression_enabled = False
     H5FILTER, H5_COMPRESS_LZ4 = None, None
 else:
     compression_enabled = True
+
+if compression_enabled:
+    # hdf5 parallel compression is broken before 1.13.1
+    if h5py.version.hdf5_version_tuple < (1, 13, 1):
+        import warnings
+
+        warnings.warn(
+            "HDF5 parallel compression has flaws prior to version 1.13.1, and can fail "
+            f"unexpectedly. The current linked version is {h5py.version.hdf5_version_tuple}.",
+            RuntimeWarning,
+        )
 
 
 class FileFormat:

--- a/caput/fileformats.py
+++ b/caput/fileformats.py
@@ -73,11 +73,6 @@ class HDF5(FileFormat):
     module = h5py
 
     @staticmethod
-    def compression_enabled():
-        """Disable compression and chunking due to bug: https://github.com/chime-experiment/Pipeline/issues/33."""
-        return False
-
-    @staticmethod
     def open(*args, **kwargs):
         """Open an HDF5 file using h5py."""
         return h5py.File(*args, **kwargs)

--- a/caput/memh5.py
+++ b/caput/memh5.py
@@ -2685,16 +2685,6 @@ def deep_group_copy(
             )
         compression_kwargs["chunks"] = getattr(dset, "chunks", None)
 
-        # disable compression if not enabled for HDF5 files
-        # https://github.com/chime-experiment/Pipeline/issues/33
-        if (
-            to_file
-            and file_format == fileformats.HDF5
-            and not fileformats.HDF5.compression_enabled()
-            and isinstance(dset, MemDatasetDistributed)
-        ):
-            compression_kwargs = {}
-
         return compression_kwargs
 
     # If copying to file, datasets are not shared, so ensure that these

--- a/tests/test_memh5_parallel.py
+++ b/tests/test_memh5_parallel.py
@@ -129,18 +129,18 @@ def test_io(
         assert "world" in f["hello"]
 
         # Check compression/chunks
-        if file_format is fileformats.Zarr:
-            if chunks is None:
+        if chunks is None:
+            if file_format is fileformats.HDF5:
+                assert f["parallel_data"].chunks is None
+
+            elif file_format is fileformats.Zarr:
                 assert f["parallel_data"].chunks == f["parallel_data"].shape
                 assert f["parallel_data"].compressor is None
-            else:
-                assert f["parallel_data"].chunks == chunks
+        else:
+            assert f["parallel_data"].chunks == chunks
+
+            if file_format is fileformats.Zarr:
                 assert f["parallel_data"].compressor is not None
-        elif file_format is fileformats.HDF5:
-            # compression should be disabled
-            # (for some reason .compression is not set...)
-            assert str(fileformats.H5FILTER) not in f["parallel_data"]._filters
-            assert f["parallel_data"].chunks is None
 
     # Test that the read in group has the same structure as the original
     g2 = memh5.MemGroup.from_file(


### PR DESCRIPTION
As discussed in #303, it looks like the parallel compression issues with HDF5 are resolved since 1.13.1. 

This PR removes the code that forcibly disabled parallel compression, so writing parallel HDF5 should now behave the same way as writing parallel `zarr`. It also fixes a test that assumed that compression would always be disabled for hdf5 files.