### PR TITLE
`hdf5` IO tweaks

### DIFF
--- a/caput/misc.py
+++ b/caput/misc.py
@@ -240,9 +240,9 @@ def open_h5py_mpi(f, mode, use_mpi=True, comm=None):
             from mpi4py import MPI
 
             comm = comm if comm is not None else MPI.COMM_WORLD
-            fh = h5py.File(f, mode, driver="mpio", comm=comm)
+            fh = h5py.File(f, mode, libver="latest", driver="mpio", comm=comm)
         else:
-            fh = h5py.File(f, mode)
+            fh = h5py.File(f, mode, libver="latest")
         fh.opened = True
     elif isinstance(f, h5py.File | h5py.Group):
         fh = f


### PR DESCRIPTION
This PR implements the following tweaks to try to speed up IO where possible:
- sets `libver="latest"` when opening files. This likely isn't significant, but it can't hurt.
- Uses `h5py.File.read_direct` and `h5py.File.write_direct` where possible. "Where possible"  is a bit vague, but from my testing it seems like it can be mildly faster with datasets with native byteorder. However, due to a bug in `h5py`, it seems to be considerably slower if any sort of endianess conversion needs to happen.
- Always try to use collective IO. We previously had this disabled if a dataset was being distributed over the 0th axis, but from my testing it seems like collective is still faster in this case (this might have just been a very outdated setting).
- Don't allow IO partitioning to split the last axis. 