### PR TITLE
fix(containers): Fix exception type

### DIFF
--- a/caput/containers/_core.py
+++ b/caput/containers/_core.py
@@ -110,7 +110,7 @@ class ContainerBase(memh5.BasicCont):
         # argument), and infer what its value should be, or None if not
         # provided
         if args and "data_group" in kwargs:
-            raise ValueError(
+            raise TypeError(
                 "Received conflicting definitions of `data_group`, as both the first "
                 "positional and a keyword argument."
             )


### PR DESCRIPTION
When an argument is passed both positionally and as a keyword, `TypeError` should be raised because the caller has mistaken the type signature of the called function.

Noticed while working through #311 

You can see this intended behaviour with something like:
```
>>> def f(a,b=0): return a+b
... 
>>> f(1,a=1)
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    f(1,a=1)
    ~^^^^^^^
TypeError: f() got multiple values for argument 'a'
```