### PR TITLE
Add method to compute frequency channel profile from PFB

### DIFF
--- a/caput/pfb.py
+++ b/caput/pfb.py
@@ -95,7 +95,7 @@ class PFB:
         This will improve accuracy.
     """
 
-    def __init__(self, ntap, lblock, window=None, oversample=4):
+    def __init__(self, ntap, lblock, window=None, oversample=16):
         self.ntap = ntap
         self.lblock = lblock
 


### PR DESCRIPTION
This adds 2 methods to `caput.pfb.PFB`:
1. `compute_channel_profile`: Computes the frequency channel profile at a naturally-spaced set of frequencies relative to the central frequency of the channel. This is useful if you just want to plot the channel profile, or construct your own interpolating function.
2. `evaluate_channel_profile`: Calls `compute_channel_profile` and stores an interpolating function when first invoked, and then evaluates the interpolating function upon subsequent calls. Useful for repeatedly evaluating the profile.

I've also increased the default oversampling rate in `caput.pfb.PFB` from 4 to 16, since I've found that 16 is needed to obtain results for CHIME's PFB that are free of noticeable interpolation artifacts.