### PR TITLE
fix(astro.constants): Redefine t_sidereal

### DIFF
--- a/caput/astro/constants.py
+++ b/caput/astro/constants.py
@@ -29,9 +29,6 @@ solar_mass: float = 1.98892e30
 second: float = 1.0
 """One second in seconds."""
 
-t_sidereal: float = 23.9344696 * hour
-"""One sidereal day in seconds, equal to `23.9344696 * hour`."""
-
 a_rad: float = 4.0 * Stefan_Boltzmann / c
 r"""Radiation constant (in J m\ :sup:`-3` K\ :sup:`-4}`, equal to `4 * Stefan_Boltzmann / c`."""
 
@@ -53,6 +50,9 @@ stellar_second: float = 1.0 / 1.00273781191135448 * UT1_second
 """Approximate length of a stellar second.
 This comes from the definition of ERA-UT1 (see IERS Conventions TR Chapter 1) giving
 the first ratio a UT1 and stellar second."""
+
+t_sidereal: float = sidereal_second * day
+"""One sidereal day in SI seconds.  This is `sidereal_second * day`."""
 
 # Aliases. Included in this dict in case we ever want
 # to change/remove them

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -17,7 +17,8 @@ def test_special_constants():
     """Check that we get the correct values for custom constants."""
     assert constants.solar_mass == 1.98892e30
     assert constants.second == 1.0
-    assert constants.t_sidereal == 86164.09056
+    assert constants.sidereal_second == 0.9972695683734868
+    assert constants.t_sidereal == 86164.09070746927
     assert constants.a_rad == 7.565733250280007e-16
     assert constants.nu21 == 1420.40575177
 


### PR DESCRIPTION
The previous definition of `t_sidereal` was defined in in terms of a magic number of SI hours.  Instead, let's directly define it in terms of the `sidereal_second` that we already have.

The difference between the new definition and the old is small:
```
(sidereal_second * day) / old_t_sidereal - 1 = 1.7114933914541552e-09
```
or less than 0.2 millisconds per day.