### PR TITLE
feat(runner): allow profiling of template jobs

### DIFF
--- a/caput/pipeline/runner/_cli.py
+++ b/caput/pipeline/runner/_cli.py
@@ -21,6 +21,60 @@ def cli():
     pass
 
 
+def profiler_options(f):
+    """Options for profiling a pipeline run."""
+    options = [
+        click.option(
+            "--profile",
+            is_flag=True,
+            default=False,
+            help=(
+                "Run the job in a profiler. This will output a `profile_<rank>.prof` file per "
+                "MPI rank if using cProfile or `profile_<rank>.txt` file for pyinstrument."
+            ),
+        ),
+        click.option(
+            "--profiler",
+            type=click.Choice(["cProfile", "pyinstrument"], case_sensitive=False),
+            default="cProfile",
+            help="Set the profiler to use. Default is cProfile.",
+        ),
+        click.option(
+            "--psutil",
+            is_flag=True,
+            default=False,
+            help=(
+                "Run the job with a psutil profiler for each task. The output "
+                "can be found in the caput logs, at the INFO level."
+            ),
+        ),
+    ]
+
+    for opt in reversed(options):
+        f = opt(f)
+
+    return f
+
+
+def mpi_abort_option(f):
+    """Option for MPI aware exception handler."""
+    options = [
+        click.option(
+            "--mpi-abort/--no-mpi-abort",
+            default=True,
+            help=(
+                "Enable an MPI aware exception handler such that all ranks will exit when any "
+                "one throws an exception."
+            ),
+        )
+    ]
+
+    for opt in reversed(options):
+        f = opt(f)
+
+    return f
+
+
 @cli.command("lint")
 @click.argument(
     "configfile",
@@ -33,48 +87,20 @@ def lint_config(configfile):
 
 
 @cli.command()
+@profiler_options
+@mpi_abort_option
 @click.argument(
     "configfile",
     type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
 )
-@click.option(
-    "--profile",
-    is_flag=True,
-    default=False,
-    help=(
-        "Run the job in a profiler. This will output a `profile_<rank>.prof` file per "
-        "MPI rank if using cProfile or `profile_<rank>.txt` file for pyinstrument."
-    ),
-)
-@click.option(
-    "--profiler",
-    type=click.Choice(["cProfile", "pyinstrument"], case_sensitive=False),
-    default="cProfile",
-    help="Set the profiler to use. Default is cProfile.",
-)
-@click.option(
-    "--mpi-abort/--no-mpi-abort",
-    default=True,
-    help=(
-        "Enable an MPI aware exception handler such that all ranks will exit when any "
-        "one throws an exception."
-    ),
-)
-@click.option(
-    "--psutil",
-    is_flag=True,
-    default=False,
-    help=(
-        "Run the job with a psutil profiler for each task. The output "
-        "can be found in the caput logs, at the INFO level."
-    ),
-)
-def run(configfile, profile, profiler, mpi_abort, psutil):
+def run(profile, profiler, psutil, mpi_abort, configfile):
     """Run a pipeline immediately from the given CONFIGFILE."""
     _core.run_pipeline(configfile, profile, profiler, mpi_abort, psutil)
 
 
 @cli.command()
+@profiler_options
+@mpi_abort_option
 @click.argument(
     "templatefile",
     type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
@@ -111,7 +137,18 @@ def run(configfile, profile, profiler, mpi_abort, psutil):
         "or -m syntax for PBS"
     ),
 )
-def template_run(templatefile, submit, var, overwrite, email=None, mailtype=None):
+def template_run(
+    profile,
+    profiler,
+    psutil,
+    mpi_abort,
+    templatefile,
+    submit,
+    var,
+    overwrite,
+    email=None,
+    mailtype=None,
+):
     """Run a pipeline from the given TEMPLATEFILE.
 
     This is either run immediately (default), or can be placed in the batch
@@ -124,12 +161,15 @@ def template_run(templatefile, submit, var, overwrite, email=None, mailtype=None
     substitutions the outer product of all possible values is generated.
     """
     if submit:
-        _scheduler.template_queue(templatefile, var, overwrite, email, mailtype)
+        _scheduler.template_queue(
+            templatefile, var, overwrite, profile, profiler, psutil, email, mailtype
+        )
     else:
-        _core.template_run(templatefile, var)
+        _core.template_run(templatefile, var, profile, profiler, mpi_abort, psutil)
 
 
 @cli.command()
+@profiler_options
 @click.argument(
     "configfile",
     type=click.Path(exists=True, dir_okay=False, readable=True, resolve_path=True),
@@ -141,30 +181,6 @@ def template_run(templatefile, submit, var, overwrite, email=None, mailtype=None
     "--lint/--nolint",
     default=True,
     help="Check the pipeline for errors before submitting it.",
-)
-@click.option(
-    "--profile",
-    is_flag=True,
-    default=False,
-    help=(
-        "Run the job in a profiler. This will output a `profile_<rank>.prof` file per "
-        "MPI rank if using cProfile or `profile_<rank>.txt` file for pyinstrument,"
-    ),
-)
-@click.option(
-    "--profiler",
-    type=click.Choice(["cProfile", "pyinstrument"], case_sensitive=False),
-    default="cProfile",
-    help="Set the profiler to use. Default is cProfile.",
-)
-@click.option(
-    "--psutil",
-    is_flag=True,
-    default=False,
-    help=(
-        "Run the job with a psutil profiler for each task. The output "
-        "can be found in the caput logs, at the INFO level."
-    ),
 )
 @click.option(
     "--overwrite",
@@ -189,12 +205,12 @@ def template_run(templatefile, submit, var, overwrite, email=None, mailtype=None
     ),
 )
 def queue(
+    profile,
+    profiler,
+    psutil,
     configfile,
     submit=False,
     lint=True,
-    profile=False,
-    profiler="cProfiler",
-    psutil=False,
     overwrite="never",
     email=None,
     mailtype=None,

--- a/caput/pipeline/runner/_core.py
+++ b/caput/pipeline/runner/_core.py
@@ -80,7 +80,14 @@ def run_pipeline(
 
 
 def template_run(  # noqa: D417
-    templatefile: os.PathLike, var: Any, *args: Any, **kwargs: Any
+    templatefile: os.PathLike,
+    var: Any,
+    profile: bool,
+    profiler: Literal["cprofile", "pyinstrument"],
+    mpi_abort: bool,
+    psutil: bool,
+    *args: Any,
+    **kwargs: Any,
 ) -> None:
     r"""Run a pipeline from the given `templatefile`.
 
@@ -102,7 +109,7 @@ def template_run(  # noqa: D417
         Keyword arguments to pass to `run_pipeline`.
     """
     for tfh_name in _from_template(templatefile, var):
-        run_pipeline(tfh_name, *args, **kwargs)
+        run_pipeline(tfh_name, profile, profiler, mpi_abort, psutil, *args, **kwargs)
 
 
 def _from_template(templatefile: os.PathLike, var: Any) -> Generator[str]:

--- a/caput/pipeline/runner/_scheduler/__init__.py
+++ b/caput/pipeline/runner/_scheduler/__init__.py
@@ -69,6 +69,9 @@ def template_queue(
     templatefile: os.PathLike,
     var: str,
     overwrite: Literal["never", "failed"],
+    profile: bool = False,
+    profiler: str | None = "cProfiler",
+    psutil: bool = False,
     email: str | None = None,
     mailtype: str | None = None,
 ):
@@ -89,6 +92,14 @@ def template_queue(
     overwrite : {"never", "failed"}
         How to handle job directories which already exist. If "failed",
         only jobs which have reported `FAILED` will be re-queued.
+    profile : bool, optional
+        If True, use a profiler to monitor the time and resource usage of
+        the pipeline job. Default is False.
+    profiler : {"cprofile", "pyinstrument"}, optional
+        Which profiler to use if `profile` is True. Default is `cprofile`.
+    psutil : bool, optional
+        If True, use `psutil` to monitor the memory use of the pipeline job.
+        Default is False.
     email : str | None, optional
         Email address for job status notifications.
     mailtype : str | None, optional
@@ -101,6 +112,9 @@ def template_queue(
         queue(
             configfile=tfh_name,
             submit=True,
+            profile=profile,
+            profiler=profiler,
+            psutil=psutil,
             overwrite=overwrite,
             email=email,
             mailtype=mailtype,


### PR DESCRIPTION
This PR is motivated by a bug that @nKrugo13 identified in the refactored pipeline routines: `caput-pipeline template-run` will throw an error if `--submit` is not specified and any of the `profile`, `profiler`, `mpi_abort`, or `psutil` arguments are missing. This happens because `_cli.template_run()` calls `_core.template_run()`, which in turn calls `_core.run_pipeline()`, for which the 4 arguments above are not optional. I believe this bug was introduced in the process of decoupling the command-line interface from `run_pipeline()`: previously, `run_pipeline()` was called directly from the command line, and always had default values for these 4 arguments provided.

In the process of fixing this bug, I realized that it would be straightforward to allow profiling of `template-run` jobs, so I've implemented that here.