### PR TITLE
Set minimum setuptools version for SPDX license expression support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools>=77",
     "wheel",
     "setuptools-git-versioning",
     "cython",


### PR DESCRIPTION
This is the min required for current `license` and `license-files` format, so it should be explicitly specified.