### PR TITLE
feat(util.pfb): add DeconvolvePFB, moved from ch_pipeline

### DIFF
--- a/caput/algorithms/__init__.py
+++ b/caput/algorithms/__init__.py
@@ -1,9 +1,12 @@
 """Fast implementations of common algorithms."""
 
+# NOTE: this must be imported before the subpackages below. `caput.algorithms.fft`
+# pulls in `caput.util`, which imports `caput.util.pfb`, which needs this name to
+# already be bound on this package.
+from ._invert_no_zero import invert_no_zero as invert_no_zero
+
 from . import (
     fft as fft,
     median as median,
     random as random,
 )
-
-from ._invert_no_zero import invert_no_zero as invert_no_zero

--- a/caput/util/pfb.py
+++ b/caput/util/pfb.py
@@ -5,6 +5,7 @@ This module can:
 - Evaluate the typical window functions used
 - Evaluate a python model of the PFB
 - Calculate the decorrelation effect for signals offset by a known time delay.
+- Deconvolve the effects of the PFB from finely channelised data.
 
 """
 
@@ -13,7 +14,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import scipy.linalg as la
+import scipy.sparse as ss
 from scipy.interpolate import CubicSpline, interp1d
+
+from ..algorithms import invert_no_zero
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -282,3 +287,213 @@ class PFB:
             )
 
         return self._decorr_interp(delay)
+
+
+class DeconvolvePFB:
+    """Deconvolve the effects of the PFB from finely channelised data.
+
+    Default parameters represent what is done within CHIME.
+
+    Parameters
+    ----------
+    N : int, optional
+        Length of a PFB tap.
+    M : int, optional
+        Number of PFB taps.
+    Q : int, optional
+        Number of subfrequencies, or equivalently the number of PFB outputs in the
+        second FFT.
+    window : callable, optional
+        The window function applied in the PFB. If not set, use a Sinc-Hamming
+        window.
+    band : int, optional
+        Number of neighbouring frequencies on either side of each output frequency
+        to include in the deconvolution.
+    nyquist : bool, optional
+        Is the nyquist frequency included in the data? Default is False to
+        match the CHIME/Caspertools PFB.
+    """
+
+    def __init__(
+        self,
+        N: int = 2048,
+        M: int = 4,
+        Q: int = 128,
+        window: Callable[[int, int], np.ndarray] = sinc_hamming,
+        band: int = 1,
+        nyquist: bool = False,
+    ):
+        """Set the PFB parameters and generate the deconvolution matrices."""
+        self.N = N
+        self.M = M
+        self.Q = Q
+        self.band = band
+        self.nyquist = nyquist
+
+        if M > Q:
+            raise ValueError(
+                f"Number of subfreq ({Q=}) must be more than the number of PFB taps "
+                f"({M=})."
+            )
+
+        w_pad = np.zeros(N * Q, dtype=np.float64)
+        w_pad[: (M * N)] = window(M, N)
+
+        self.Wt = np.fft.fft(w_pad).conj().reshape(N, Q).transpose(1, 0) / N
+        self.Wt2 = np.abs(self.Wt) ** 2
+
+        self._gen_matrices_sparse()
+
+    def _gen_matrices_dense(self):
+        """Generate the deconvolution matrices as dense arrays.
+
+        This is slow, but is a good reference implementation that the sparse matrices
+        are doing the correct thing.
+        """
+        Q = self.Q
+        N = self.N
+        band = self.band
+
+        self.W = np.zeros((Q, N, N), dtype=np.float64)
+
+        for ri in range(N):
+            for alpha in range(-band, band):
+                self.W[:, ri, (ri + alpha) % N] = self.Wt2[:, alpha]
+
+        # Construct the matrix to project from the positive frequencies to the full
+        # space
+        self.Hf = np.zeros((N, N // 2 + 1), dtype=np.float64)
+        for ri in range(N // 2 + 1):
+            self.Hf[ri, ri] = 1.0
+        for ri in range(N // 2 - 1):
+            hN = N // 2
+            self.Hf[hN + ri + 1, hN - ri - 1] = 1.0
+
+        # Construct the matrix to go from the full frequencies to the positive
+        # frequencies (excluding Nyquist)
+        Nb = N // 2 + (1 if self.nyquist else 0)
+        self.Hb = np.zeros((Nb, N), dtype=np.float64)
+        for ri in range(Nb):
+            self.Hb[ri, ri] = 1.0
+
+        self.Wc = np.zeros((Q, Nb, N // 2 + 1), dtype=np.float64)
+
+        for s in range(Q):
+            self.Wc[s] = self.Hb @ self.W[s] @ self.Hf
+
+    def _gen_matrices_sparse(self):
+        """Generate the deconvolution matrices as sparse arrays."""
+        Q = self.Q
+        N = self.N
+        band = self.band
+
+        self.W = []
+
+        # Pre-generate arrays for the row and col indices which are the same for each
+        # subfreq
+        row_ind = np.zeros((2 * band, N), dtype=np.int32)
+        row_ind[:] = np.arange(N)[np.newaxis, :]
+        band_ind = np.arange(-band, band, dtype=np.int32)
+        col_ind = (row_ind + band_ind[:, np.newaxis]) % N
+
+        data = np.zeros((2 * band, N), dtype=np.float64)
+
+        for s in range(Q):
+            data[:] = self.Wt2[s, band_ind][:, np.newaxis]
+            self.W.append(
+                ss.csr_array(
+                    (data.ravel(), (row_ind.ravel(), col_ind.ravel())), shape=(N, N)
+                )
+            )
+
+        # Construct the matrix to project from the positive frequencies to the full
+        # space
+        self.Hf = ss.lil_array((N, N // 2 + 1), dtype=np.float64)
+        for ri in range(N // 2 + 1):
+            self.Hf[ri, ri] = 1.0
+        for ri in range(N // 2 - 1):
+            hN = N // 2
+            self.Hf[hN + ri + 1, hN - ri - 1] = 1.0
+        self.Hf = self.Hf.tocsr()
+
+        # Construct the matrix to go from the full frequencies to the positive
+        # frequencies (excluding Nyquist)
+        Nb = N // 2 + (1 if self.nyquist else 0)
+        self.Hb = ss.lil_array((Nb, N), dtype=np.float64)
+        for ri in range(Nb):
+            self.Hb[ri, ri] = 1.0
+        self.Hb = self.Hb.tocsr()
+
+        self.Wc = [self.Hb @ self.W[s] @ self.Hf for s in range(Q)]
+
+    def flatten(
+        self, x: npt.NDArray, Ni: npt.NDArray, centered: bool = True
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Fit the data to remove the quantisation noise bias and the PFB shape.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Data array packed as [freq, subfreq, time].
+        Ni : np.ndarray
+            Weights (i.e. inverse noise variance) packed the same way as x.
+        centered : bool, optional
+            Is the data centered (i.e. as it is in the raw data) or shifted such that
+            subfreq=0 is the DC bin.
+
+        Returns
+        -------
+        fx : np.ndarray
+            Flattened data with the bias subtracted out and divided by the bandpass and
+            the average flux.
+        fNi : np.ndarray
+            Weights with the equivalent flattening correction applied.
+        """
+        # TODO: expose these parameters
+        sig_a = 1e4
+        sig_b = 1e4
+        sig_d = 1e4
+
+        # This is the subfreq template to fit
+        w = self.Wt2.sum(axis=1)
+
+        if centered:
+            w = np.roll(w, self.Q // 2)
+
+        # We need to construct all the products efficiently. This section tries to build
+        # up all the needed combinations.
+        wN = w[np.newaxis, :, np.newaxis] * Ni
+        zN = Ni
+        # Quadratic products
+        wNw = (wN * w[np.newaxis, :, np.newaxis]).sum(axis=1)
+        zNw = (zN * w[np.newaxis, :, np.newaxis]).sum(axis=1)
+        zNz = zN.sum(axis=1)
+        # Products against the data
+        wNd = (wN * x).sum(axis=1)
+        zNd = (zN * x).sum(axis=1)
+
+        # Construct the inverse covariance term via Sherman-Morrison using the products
+        # above
+        Ci = np.empty((x.shape[0], 2, 2), dtype=np.float64)
+        Ci[:, 0, 0] = np.sum(wNw - sig_d**2 / (1 + sig_d**2 * wNw) * wNw**2, axis=-1)
+        Ci[:, 0, 1] = np.sum(zNw - sig_d**2 / (1 + sig_d**2 * wNw) * zNw * wNw, axis=-1)
+        Ci[:, 1, 0] = Ci[:, 0, 1]
+        Ci[:, 1, 1] = np.sum(zNz - sig_d**2 / (1 + sig_d**2 * wNw) * zNw**2, axis=-1)
+        # Add in the signal term
+        Ci[:, 0, 0] += sig_a**-2
+        Ci[:, 1, 1] += sig_b**-2
+
+        # Construct the "dirty" estimator
+        dirty = np.empty((x.shape[0], 2), dtype=np.float64)
+        dirty[:, 0] = np.sum(wNd - sig_d**2 / (1 + sig_d**2 * wNw) * wNw * wNd, axis=-1)
+        dirty[:, 1] = np.sum(zNd - sig_d**2 / (1 + sig_d**2 * wNw) * zNw * wNd, axis=-1)
+
+        # Solve for a and b, and then apply to the data
+        fx = np.empty_like(x)
+        fNi = np.empty_like(Ni)
+        for ii in range(x.shape[0]):
+            a, b = la.solve(Ci[ii], dirty[ii], assume_a="pos")
+            fx[ii] = (x[ii] - b) * invert_no_zero(a * w[:, np.newaxis])
+            fNi[ii] = (a * w[:, np.newaxis]) ** 2 * Ni[ii]
+
+        return fx, fNi


### PR DESCRIPTION
Move the `DeconvolvePFB` class from `ch_pipeline.hfb.pfb` into `caput.util.pfb`, next to the PFB model and window functions it is built on. The deconvolution is not CHIME-specific, so it belongs alongside the rest of the CASPER PFB tooling.

The numerical behaviour is unchanged. Adjustments made while moving:

- Use `caput.algorithms.invert_no_zero` instead of `draco.util.tools.invert_no_zero`, dropping the draco dependency.
- Reference `sinc_hamming` directly rather than via the `caput.util.pfb` module namespace.
- Import `invert_no_zero` before the subpackages in `caput.algorithms.__init__`, so that the `caput.algorithms.fft` -> `caput.util` -> `caput.util.pfb` chain does not hit a partially initialised `caput.algorithms`.
- Convert docstrings to the typed numpydoc style used elsewhere in this module, document the previously undocumented `band` parameter, and give the matrix generators docstrings.
- Drop a stale commented-out call to a `_gen_matrices` method that does not exist.

Companion PR: chime-experiment/ch_pipeline#329

See also issue https://github.com/chime-experiment/ch_pipeline/issues/328